### PR TITLE
Add server endpoints

### DIFF
--- a/source/includes/_misc.md
+++ b/source/includes/_misc.md
@@ -258,7 +258,7 @@ curl -X POST "https://abs.example.com/api/authorize" \
 }
 ```
 
-This endpoint retrieves information about the authorized user and the server. Used for logging into a client if an API token was persisted. Returns the same payload as `/login`.
+This endpoint retrieves information about the authorized user and the server. Used for logging into a client if an API token was persisted. Returns the same payload as `/login` ([Login](#login)).
 
 ### HTTP Request
 

--- a/source/includes/_schemas.md
+++ b/source/includes/_schemas.md
@@ -1090,7 +1090,7 @@ Attribute | Type | Description
 `startOffset` | Float | When in the audio file (in seconds) the track starts.
 `duration` | Float | The length (in seconds) of the audio track.
 `title` | String | The filename of the audio file the audio track belongs to.
-`contentUrl` | String | The URL on the serve of the audio file.
+`contentUrl` | String | The URL path of the audio file.
 `mimeType` | String | The MIME type of the audio file.
 `metadata` | [File Metadata](#file-metadata) Object or null | The metadata of the audio file.
 

--- a/source/includes/_server.md
+++ b/source/includes/_server.md
@@ -1,0 +1,136 @@
+# Server
+
+## Login
+
+```shell
+curl -X POST "https://abs.example.com/login" \
+  -H "Content-Type: application/json" \
+  -d '{"username": "root", "password": "*****"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "user": {
+    "id": "root",
+    "username": "root",
+    "type": "root",
+    "token": "exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY",
+    "mediaProgress": [
+      {
+        "id": "li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv",
+        "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+        "episodeId": "ep_lh6ko39pumnrma3dhv",
+        "duration": 1454.18449,
+        "progress": 0.434998929881311,
+        "currentTime": 632.568697,
+        "isFinished": false,
+        "hideFromContinueListening": false,
+        "lastUpdate": 1668586015691,
+        "startedAt": 1668120083771,
+        "finishedAt": null
+      }
+    ],
+    "seriesHideFromContinueListening": [],
+    "bookmarks": [],
+    "isActive": true,
+    "isLocked": false,
+    "lastSeen": 1669010786013,
+    "createdAt": 1666543632566,
+    "settings": {
+      "mobileOrderBy": "addedAt",
+      "mobileOrderDesc": true,
+      "mobileFilterBy": "all",
+      "orderBy": "media.metadata.title",
+      "orderDesc": false,
+      "filterBy": "all",
+      "playbackRate": 1,
+      "bookshelfCoverSize": 120,
+      "collapseSeries": false,
+      "useChapterTrack": true
+    },
+    "permissions": {
+      "download": true,
+      "update": true,
+      "delete": true,
+      "upload": true,
+      "accessAllLibraries": true,
+      "accessAllTags": true,
+      "accessExplicitContent": true
+    },
+    "librariesAccessible": [],
+    "itemTagsAccessible": []
+  },
+  "userDefaultLibraryId": "lib_c1u6t4p45c35rf0nzd",
+  "serverSettings": {
+    "id": "server-settings",
+    "scannerFindCovers": false,
+    "scannerCoverProvider": "audible",
+    "scannerParseSubtitle": false,
+    "scannerPreferAudioMetadata": false,
+    "scannerPreferOpfMetadata": false,
+    "scannerPreferMatchedMetadata": false,
+    "scannerDisableWatcher": true,
+    "scannerPreferOverdriveMediaMarker": false,
+    "scannerUseSingleThreadedProber": true,
+    "scannerMaxThreads": 0,
+    "scannerUseTone": false,
+    "storeCoverWithItem": false,
+    "storeMetadataWithItem": false,
+    "rateLimitLoginRequests": 10,
+    "rateLimitLoginWindow": 600000,
+    "backupSchedule": "30 1 * * *",
+    "backupsToKeep": 2,
+    "maxBackupSize": 1,
+    "backupMetadataCovers": true,
+    "loggerDailyLogsToKeep": 7,
+    "loggerScannerLogsToKeep": 2,
+    "homeBookshelfView": 1,
+    "bookshelfView": 1,
+    "sortingIgnorePrefix": false,
+    "sortingPrefixes": [
+      "the",
+      "a"
+    ],
+    "chromecastEnabled": false,
+    "enableEReader": false,
+    "dateFormat": "MM/dd/yyyy",
+    "language": "en-us",
+    "logLevel": 2,
+    "version": "2.2.5"
+  },
+  "feeds": [],
+  "Source": "docker"
+}
+```
+
+This endpoint logs in a client to the server, returning information about the user and server. The `/api/authorize` ([Get Authorized User and Server Information](#get-authorized-user-and-server-information)) endpoint is also available if an API token was persisted.
+
+### HTTP Request
+
+`POST http://abs.example.com/login`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`username` | String | The username to log in with.
+`password` | String | The password of the user.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+401 | Unauthorized | Invalid username or password. | Error Message
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`user` | [User](#user) Object | The authenticated user.
+`userDefaultLibraryId` | String | The ID of the first library in the list the user has access to.
+`serverSettings` | [Server Settings](#server-settings) Object | The server's settings.
+`feeds` | Array of [RSS Feed](#rss-feed) | The open RSS feeds.
+`Source` | String | The server's installation source.

--- a/source/includes/_server.md
+++ b/source/includes/_server.md
@@ -134,3 +134,31 @@ Attribute | Type | Description
 `serverSettings` | [Server Settings](#server-settings) Object | The server's settings.
 `feeds` | Array of [RSS Feed](#rss-feed) | The open RSS feeds.
 `Source` | String | The server's installation source.
+
+
+## Logout
+
+```shell
+curl -X POST "https://abs.example.com/logout" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"socketId": "AFcTcb7xBLsSPnIzAAAV"}'
+```
+
+This endpoint logs out a client from the server. If the `socketId` parameter is provided, the server removes the socket from the client list.
+
+### HTTP Request
+
+`POST http://abs.example.com/logout`
+
+### Optional Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`socketId` | String | The ID of the connected socket.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success

--- a/source/includes/_server.md
+++ b/source/includes/_server.md
@@ -145,7 +145,7 @@ curl -X POST "https://abs.example.com/logout" \
   -d '{"socketId": "AFcTcb7xBLsSPnIzAAAV"}'
 ```
 
-This endpoint logs out a client from the server. If the `socketId` parameter is provided, the server removes the socket from the client list.
+This endpoint logs out a client from the server. If the `socketId` parameter is provided, the server removes the socket from the client list. When using a socket connection this allows a client to change the user without needing to re-create the socket connection.
 
 ### HTTP Request
 

--- a/source/includes/_server.md
+++ b/source/includes/_server.md
@@ -234,3 +234,36 @@ Attribute | Type | Description
 `language` | String | The server's default language.
 `ConfigPath` | String | The server's config path. Will only exist if `isInit` is `false`.
 `MetadataPath` | String | The server's metadata path. Will only exist if `isInit` is `false`.
+
+
+## Ping the Server
+
+```shell
+curl "https://abs.example.com/ping"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "success": true
+}
+```
+
+This endpoint is a simple check to see if the server is operating and responding with JSON correctly.
+
+### HTTP Request
+
+`GET http://abs.example.com/ping`
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`success` | Boolean | Will always be `true`.

--- a/source/includes/_server.md
+++ b/source/includes/_server.md
@@ -162,3 +162,38 @@ Parameter | Type | Description
 Status | Meaning | Description
 ------ | ------- | -----------
 200 | OK | Success
+
+
+## Initialize a Server
+
+```shell
+curl -X POST "https://abs.example.com/init" \
+  -H "Content-Type: application/json" \
+  -d '{"username": "root", "password": "*****"}'
+```
+
+This endpoint initializes a server for use with a root user.
+
+### HTTP Request
+
+`POST http://abs.example.com/init`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`newRoot` | [New Root User](#new-root-user-parameters) Object (See Below) | The new root user.
+
+#### New Root User Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`username` | String | The username of the new root user.
+`password` | String | The password of the new root user, may be empty.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+500 | Internal Server Error | The server has already been initialized.

--- a/source/includes/_server.md
+++ b/source/includes/_server.md
@@ -164,7 +164,7 @@ Status | Meaning | Description
 200 | OK | Success
 
 
-## Initialize a Server
+## Initialize the Server
 
 ```shell
 curl -X POST "https://abs.example.com/init" \
@@ -197,3 +197,40 @@ Status | Meaning | Description
 ------ | ------- | -----------
 200 | OK | Success
 500 | Internal Server Error | The server has already been initialized.
+
+
+## Check the Server's Status
+
+```shell
+curl "https://abs.example.com/status"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "isInit": true,
+  "language": "en-us"
+}
+```
+
+This endpoint reports the server's initialization status.
+
+### HTTP Request
+
+`GET http://abs.example.com/init`
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`isInit` | Boolean | Whether the server has been initialized.
+`language` | String | The server's default language.
+`ConfigPath` | String | The server's config path. Will only exist if `isInit` is `false`.
+`MetadataPath` | String | The server's metadata path. Will only exist if `isInit` is `false`.

--- a/source/includes/_server.md
+++ b/source/includes/_server.md
@@ -267,3 +267,22 @@ Status | Meaning | Description | Schema
 Attribute | Type | Description
 --------- | ---- | -----------
 `success` | Boolean | Will always be `true`.
+
+
+## Healthcheck
+
+```shell
+curl "https://abs.example.com/healthcheck"
+```
+
+This endpoint is a simple check to see if the server is operating and can respond.
+
+### HTTP Request
+
+`GET http://abs.example.com/healthcheck`
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success

--- a/source/includes/_server.md
+++ b/source/includes/_server.md
@@ -172,7 +172,7 @@ curl -X POST "https://abs.example.com/init" \
   -d '{"username": "root", "password": "*****"}'
 ```
 
-This endpoint initializes a server for use with a root user.
+This endpoint initializes a server for use with a root user. This is required for new servers without a root user yet.
 
 ### HTTP Request
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -9,6 +9,7 @@ toc_footers:
   - <a href='https://github.com/slatedocs/slate'>Documentation Powered by Slate</a>
 
 includes:
+  - server
   - libraries
   - items
   - users
@@ -50,6 +51,8 @@ If you are a .NET developer we could use your help with a Windows installer for 
 Audiobookshelf uses a users API token as a Bearer token for requests. For GET requests the API token can optionally be passed in as a query string.
 
 You can find your API token by logging into the Audiobookshelf web app as an admin, go to the config → users page, and click on your account.
+
+You may also get the API token programmatically using the [Login](#login) endpoint. The API token will be in the response at `response.user.token`.
 
 API request header for authentication would look like this:
 


### PR DESCRIPTION
This adds some of the endpoints that are in `Server.start()`. I titled this section "Server" as I couldn't think of a better name, but there probably is one.
Also, I wasn't sure if I should add the `/metadata`, `/hls`, `/s`, `/ebook`, and `/feed` endpoints.