### PR TITLE
Remove Pull Request Warning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-<!--
-⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️
-
-👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
--->


### PR DESCRIPTION
This patch removes the pull request warning which tells you to change the base repository since it should no longer apply if you fork from this repository:


![Screenshot from 2022-11-23 16-58-54](https://user-images.githubusercontent.com/1008395/203598156-f6a34e0d-be61-4e22-b9af-3695f2802d29.png)
