### PR TITLE
Update to 2.2.7

### DIFF
--- a/source/includes/_filtering.md
+++ b/source/includes/_filtering.md
@@ -1,32 +1,51 @@
 # Filtering
 
-Most filters are composed of two parts, a group and a value, put together as `group.value`. The groups are: genres, tags, series, authors, progress, narrators, missing, and languages.
+Most filters are composed of two parts, a group and a value, put together as `group.value`.
 
-* For the genres, tags, narrators, and languages groups, the value is what genre, tag, narrator, or language to filter by.
-* For the series and authors groups, the value is the ID of the series or author.
-* For the series group, the value can also be No Series.
-* For the progress group, the value can be:
-  * Finished
-  * Not Started
-  * Not Finished
-  * In Progress
-* For the missing group, the value can be:
-  * ASIN
-  * ISBN
-  * Subtitle
-  * Author
-  * Publisher Year
-  * Series
-  * Description
-  * Genres
-  * Tags
-  * Narrator
-  * Publisher
-  * Language
+The groups are:
+
+* `genres`
+* `tags`
+* `series`
+* `authors`
+* `progress`
+* `narrators`
+* `missing`
+* `languages`
+* `tracks`
+
+The `series`, `authors`, `narrators`, `missing`, and `tracks` groups only apply to books.
+
+The available values depend on the group:
+
+* For the `genres`, `tags`, `narrators`, and `languages` groups, the value is what genre, tag, narrator, or language to filter by.
+* For the `series` and `authors` groups, the value is the ID of the series or author.
+* For the `series` group, the value can also be `no-series`.
+* For the `progress` group, the value can be:
+  * `finished`
+  * `not-started`
+  * `not-finished`
+  * `in-progress`
+* For the `missing` group, the value can be:
+  * `asin`
+  * `isbn`
+  * `subtitle`
+  * `authors`
+  * `publishedYear`
+  * `series`
+  * `description`
+  * `genres`
+  * `tags`
+  * `narrators`
+  * `publisher`
+  * `language`
+* For the `tracks` group, the value can be:
+  * `single`
+  * `multi`
 
 All values must be first Base64 encoded and then URL encoded.
 
-Other filters are issues and feed-open.
+Other filters are `issues` and `feed-open`.
 
 Examples:
 

--- a/source/includes/_libraries.md
+++ b/source/includes/_libraries.md
@@ -648,7 +648,7 @@ limit | Integer | Limit the number of returned results per page. If `0`, no limi
 page | Integer | The page number (0 indexed) to request. If there is no limit applied, then page will have no effect and all results will be returned.
 sort | String | What to sort the results by. By default, the results will be sorted by series name. Other sort options are: numBooks, totalDuration, and addedAt.
 desc | Binary | Whether to reverse the sort order. `0` for false, `1` for true.
-filter | String | What to filter the results by. See [Filtering](#filtering). The issues and feed-open filters are not available for this endpoint.
+filter | String | What to filter the results by. See [Filtering](#filtering). The `issues` and `feed-open` filters are not available for this endpoint.
 minified | Binary | Whether to request minified objects. `0` for false, `1` for true.
 
 ### Response


### PR DESCRIPTION
Updates "Filtering" section with changes from version [2.2.7](https://github.com/advplyr/audiobookshelf/releases/tag/v2.2.7) of the server.

Changes:
- Updated `progress` filter values
- Updated `missing` filter values
- Added `tracks` filter group
- Formatting update