### PR TITLE
Move metadata providers

### DIFF
--- a/source/includes/_items.md
+++ b/source/includes/_items.md
@@ -1180,7 +1180,7 @@ ID | The ID of the library item.
 
 Parameter | Type | Default | Description
 --------- | ---- | ------- | -----------
-`provider` | String | `google` | The metadata provider to search. See [Library Metadata Providers](#library-metadata-providers) for a list of options.
+`provider` | String | `google` | The metadata provider to search. See [Metadata Providers](#metadata-providers) for a list of options.
 `title` | String | The library item's title. | The title to search for.
 `author` | String | The library item's author. | The author to search for.
 `overrideDefaults` | Boolean | `false` | Whether to override the existing book details and cover. This will be `true` if the "Prefer matched metadata" server setting is enabled.
@@ -2507,7 +2507,7 @@ Parameter | Type | Description
 
 Parameter | Type | Default | Description
 --------- | ---- | ------- | -----------
-`provider` | String | `google` | The metadata provider to search. See [Library Metadata Providers](#library-metadata-providers) for a list of options.
+`provider` | String | `google` | The metadata provider to search. See [Metadata Providers](#metadata-providers) for a list of options.
 `overrideDefaults` | Boolean | `false` | Whether to override the existing book details and cover. This will be `true` if the "Prefer matched metadata" server setting is enabled.
 
 ### Response

--- a/source/includes/_libraries.md
+++ b/source/includes/_libraries.md
@@ -51,7 +51,7 @@ Parameter | Type | Default | Description
 `folders` | Array of [Folder](#folder) | **Required** | The folders of the library. Only specify the `fullPath`.
 `icon` | String | `database` | The icon of the library. See [Library Icons](#library-icons) for a list of possible icons.
 `mediaType` | String | `book` | The type of media that the library contains. Must be `book` or `podcast`.
-`provider` | String | `google` | Preferred metadata provider for the library. See [Library Metadata Providers](#library-metadata-providers) for a list of possible providers.
+`provider` | String | `google` | Preferred metadata provider for the library. See [Metadata Providers](#metadata-providers) for a list of possible providers.
 `settings` | [Library Settings](#library-settings) Object | See Below | The settings for the library.
 
 #### Library Settings Parameters
@@ -304,7 +304,7 @@ Parameter | Type | Description
 `folders` | Array of [Folder](#folder) | See the notice below. Only specify the `fullPath` for new folders.
 `displayOrder` | Integer | Display position of the library in the list of libraries. Must be `>= 1`.
 `icon` | String | The icon of the library. See [Library Icons](#library-icons) for a list of possible icons.
-`provider` | String | Preferred metadata provider for the library. See [Library Metadata Providers](#library-metadata-providers) for a list of possible providers.
+`provider` | String | Preferred metadata provider for the library. See [Metadata Providers](#metadata-providers) for a list of possible providers.
 `settings` | [Library Settings](#library-settings) Object | The settings for the library.
 
 #### Library Settings Parameters
@@ -2418,25 +2418,3 @@ Available library icons are:
 * <span class="abs-icons icon-star"></span> `star`
 * <span class="abs-icons icon-heart"></span> `heart`
 
-
-## Library Metadata Providers
-
-For book libraries:
-
-* `google`
-* `openlibrary`
-* `itunes`
-* `audible`
-* `audible.ca`
-* `audible.uk`
-* `audible.au`
-* `audible.fr`
-* `audible.de`
-* `audible.jp`
-* `audible.it`
-* `audible.in`
-* `audible.es`
-
-For podcast libraries:
-
-* `itunes`

--- a/source/includes/_metadata_providers.md
+++ b/source/includes/_metadata_providers.md
@@ -1,0 +1,25 @@
+# Metadata Providers
+
+## Books
+
+Value | Display Name
+----- | ------------
+`google` | Google Books
+`openlibrary` | Open Library
+`itunes` | iTunes
+`audible` | Audible.com
+`audible.ca` | Audible.ca
+`audible.uk` | Audible.co.uk
+`audible.au` | Audible.com.au
+`audible.fr` | Audible.fr
+`audible.de` | Audible.de
+`audible.jp` | Audible.co.jp
+`audible.it` | Audible.it
+`audible.in` | Audible.co.in
+`audible.es` | Audible.es
+
+## Podcasts
+
+Value | Display Name
+----- | ------------
+`itunes` | iTunes

--- a/source/includes/_schemas.md
+++ b/source/includes/_schemas.md
@@ -27,7 +27,7 @@ Attribute | Type | Description
 `displayOrder` | Integer | Display position of the library in the list of libraries. Must be `>= 1`.  
 `icon` | String | The selected icon for the library. See [Library Icons](#library-icons) for a list of possible icons.
 `mediaType` | String | The type of media that the library contains. Will be `book` or `podcast`. (Read Only)
-`provider` | String | Preferred metadata provider for the library. See [Library Metadata Providers](#library-metadata-providers) for a list of possible providers.
+`provider` | String | Preferred metadata provider for the library. See [Metadata Providers](#metadata-providers) for a list of possible providers.
 `settings` | [Library Settings](#library-settings) Object | The settings for the library.
 `createdAt` | Integer | The time (in ms since POSIX epoch) when the library was created. (Read Only)
 `lastUpdate` | Integer | The time (in ms since POSIX epoch) when the library was last updated. (Read Only)
@@ -2086,7 +2086,7 @@ Attribute | Type | Description
 --------- | ---- | -----------
 `id` | String | The ID of the server settings.
 `scannerFindCovers` | Boolean | Whether the scanner will attempt to find a cover if your audiobook does not have an embedded cover or a cover image inside the folder. Note: This will extend scan time.
-`scannerCoverProvider` | String | If `scannerFindCovers` is `true`, which metadata provider to use. See [Library Metadata Providers](#library-metadata-providers) for options.
+`scannerCoverProvider` | String | If `scannerFindCovers` is `true`, which metadata provider to use. See [Metadata Providers](#metadata-providers) for options.
 `scannerParseSubtitle` | Boolean | Whether to extract subtitles from audiobook folder names. Subtitles must be separated by ` - `, i.e. `/audiobooks/Book Title - A Subtitle Here/` has the subtitle `A Subtitle Here`.
 `scannerPreferAudioMetadata` | Boolean | Whether to use audio file ID3 meta tags instead of folder names for book details.
 `scannerPreferOpfMetadata` | Boolean | Whether to use OPF file metadata instead of folder names for book details.

--- a/source/includes/_search.md
+++ b/source/includes/_search.md
@@ -43,7 +43,7 @@ Parameter | Type | Default | Description
 `podcast` | Binary | `0` | Whether to search for podcast covers. Only the `title` parameter is needed for podcasts. `0` for false, `1` for true.
 `title` | String | **Required** | The media title to search for.
 `author` | String or null | `null` | If searching for a book cover, the author to search for.
-`provider` | String | `google` | If searching for a book cover, the metadata provider to use. See [Library Metadata Providers](#library-metadata-providers) for options.
+`provider` | String | `google` | If searching for a book cover, the metadata provider to use. See [Metadata Providers](#metadata-providers) for options.
 
 ### Response
 
@@ -196,7 +196,7 @@ Parameter | Type | Default | Description
 --------- | ---- | ------- | -----------
 `title` | String | `''` | The book title to search for. If using Audible for `provider`, can also be the book's ASIN.
 `author` | String | `''` | The author to search for.
-`provider` | String | `google` | The metadata provider to use. See [Library Metadata Providers](#library-metadata-providers) for options.
+`provider` | String | `google` | The metadata provider to use. See [Metadata Providers](#metadata-providers) for options.
 
 ### Response
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -27,6 +27,7 @@ includes:
   - cache
   - tools
   - misc
+  - metadata_providers
   - filtering
   - schemas
 


### PR DESCRIPTION
As discussed on matrix, this moves "Metadata Providers" to its own section. I also added display names for the values.

Changes:
- Moved metadata providers to its own section above filtering
- Put information into table and added display name
- Updated links