### PR TITLE
Sort TOC includes, and the sections of the includes

### DIFF
--- a/source/includes/_authors.md
+++ b/source/includes/_authors.md
@@ -1,56 +1,5 @@
 # Authors
 
-## Search for Authors
-
-```shell
-curl "https://abs.example.com/api/authors/search?q=Terry%20Goodkind" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "results": [
-    {
-      "id": "aut_z3leimgybl7uf3y4ab",
-      "asin": null,
-      "name": "Terry Goodkind",
-      "description": null,
-      "imagePath": null,
-      "addedAt": 1650621073750,
-      "updatedAt": 1650621073750
-    }
-  ]
-}
-```
-
-This endpoint searches for authors that match the query and returns the results.
-
-### HTTP Request
-
-`GET https://abs.example.com/api/authors/search?<q>`
-
-### Query Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-q | String | **Required** | The URL encoded search query.
-limit | Integer | `25` | Limit the number of returned results.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`results` | Array of [Author](#author) | The author search results.
-
-
 ## Get an Author
 
 ```shell
@@ -229,37 +178,21 @@ Attribute | Type | Description
 `items` | Array of [Library Item Minified](#library-item-minified) | The items in the series. Each library item's media's metadata will have a `series` attribute, a [Series Sequence](#series-sequence), which is the matching series.
 
 
-## Update an Author
+## Get an Author's Image
 
 ```shell
-curl -X PATCH "https://abs.example.com/api/authors/aut_z3leimgybl7uf3y4ab" \
+curl "https://abs.example.com/api/authors/aut_z3leimgybl7uf3y4ab/image" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"asin": "B000APZOQA"}'
+  --output author.webp
 ```
 
-> The above command returns JSON structured like this:
+> The above command writes an image file.
 
-```json
-{
-  "author": {
-    "id": "aut_z3leimgybl7uf3y4ab",
-    "asin": "B000APZOQA",
-    "name": "Terry Goodkind",
-    "description": null,
-    "imagePath": null,
-    "addedAt": 1650621073750,
-    "updatedAt": 1668506755298
-  },
-  "success": true
-}
-```
-
-This endpoint updates an author. It also allows for merging of two authors if the name of this author is set to the name of another author.
+This endpoint retrieves an author's image.
 
 ### HTTP Request
 
-`PATCH http://abs.example.com/api/authors/<ID>`
+`GET http://abs.example.com/api/authors/<ID>/image`
 
 ### URL Parameters
 
@@ -267,30 +200,22 @@ Parameter | Description
 --------- | -----------
 ID | The ID of the author.
 
-### Parameters
+### Optional Query Parameters
 
-Parameter | Type | Description
---------- | ---- | -----------
-`asin` | String or null | The ASIN of the author.
-`name` | String | The name of the author.
-`description` | String or null | A description of the author.
-`imagePath` | String or null | The absolute path for the author image.
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`width` | Integer | `400` | The requested width of the image.
+`height` | Integer or null | `null` | The requested height of the image. If `null` the image is scaled proportionately.
+`format` | String | `webp` or `jpeg` | The requested format of the image. The default value depends on the request headers.
+`raw` | Binary | `0` | Whether to get the raw cover image file instead of a scaled version. `0` for false, `1` for true.
 
 ### Response
 
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-404 | Not Found | No author with provided ID exists. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`author` | [Author](#author) Object | The updated author.
-`merged` | Boolean | Will only exist and be `true` if the author was merged with another author.
-`updated` | Boolean | Whether the author was updated normally. Will only exist if the author was not merged.
-
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+404 | Not Found | No author with provided ID exists, or the author does not have an image.
+500 | Internal Server Error | There was an error when attempting to read the image file.
 
 ## Match an Author
 
@@ -354,21 +279,88 @@ Attribute | Type | Description
 `author` | [Author](#author) Object | The updated author.
 
 
-## Get an Author's Image
+## Search for Authors
 
 ```shell
-curl "https://abs.example.com/api/authors/aut_z3leimgybl7uf3y4ab/image" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  --output author.webp
+curl "https://abs.example.com/api/authors/search?q=Terry%20Goodkind" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
-> The above command writes an image file.
+> The above command returns JSON structured like this:
 
-This endpoint retrieves an author's image.
+```json
+{
+  "results": [
+    {
+      "id": "aut_z3leimgybl7uf3y4ab",
+      "asin": null,
+      "name": "Terry Goodkind",
+      "description": null,
+      "imagePath": null,
+      "addedAt": 1650621073750,
+      "updatedAt": 1650621073750
+    }
+  ]
+}
+```
+
+This endpoint searches for authors that match the query and returns the results.
 
 ### HTTP Request
 
-`GET http://abs.example.com/api/authors/<ID>/image`
+`GET https://abs.example.com/api/authors/search?<q>`
+
+### Query Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+q | String | **Required** | The URL encoded search query.
+limit | Integer | `25` | Limit the number of returned results.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`results` | Array of [Author](#author) | The author search results.
+
+
+## Update an Author
+
+```shell
+curl -X PATCH "https://abs.example.com/api/authors/aut_z3leimgybl7uf3y4ab" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"asin": "B000APZOQA"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "author": {
+    "id": "aut_z3leimgybl7uf3y4ab",
+    "asin": "B000APZOQA",
+    "name": "Terry Goodkind",
+    "description": null,
+    "imagePath": null,
+    "addedAt": 1650621073750,
+    "updatedAt": 1668506755298
+  },
+  "success": true
+}
+```
+
+This endpoint updates an author. It also allows for merging of two authors if the name of this author is set to the name of another author.
+
+### HTTP Request
+
+`PATCH http://abs.example.com/api/authors/<ID>`
 
 ### URL Parameters
 
@@ -376,19 +368,26 @@ Parameter | Description
 --------- | -----------
 ID | The ID of the author.
 
-### Optional Query Parameters
+### Parameters
 
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`width` | Integer | `400` | The requested width of the image.
-`height` | Integer or null | `null` | The requested height of the image. If `null` the image is scaled proportionately.
-`format` | String | `webp` or `jpeg` | The requested format of the image. The default value depends on the request headers.
-`raw` | Binary | `0` | Whether to get the raw cover image file instead of a scaled version. `0` for false, `1` for true.
+Parameter | Type | Description
+--------- | ---- | -----------
+`asin` | String or null | The ASIN of the author.
+`name` | String | The name of the author.
+`description` | String or null | A description of the author.
+`imagePath` | String or null | The absolute path for the author image.
 
 ### Response
 
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-404 | Not Found | No author with provided ID exists, or the author does not have an image.
-500 | Internal Server Error | There was an error when attempting to read the image file.
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+404 | Not Found | No author with provided ID exists. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`author` | [Author](#author) Object | The updated author.
+`merged` | Boolean | Will only exist and be `true` if the author was merged with another author.
+`updated` | Boolean | Whether the author was updated normally. Will only exist if the author was not merged.

--- a/source/includes/_backups.md
+++ b/source/includes/_backups.md
@@ -1,51 +1,31 @@
 # Backups
 
-## Get All Backups
+## Apply a Backup
 
 ```shell
-curl "https://abs.example.com/api/backups" \
+curl "https://abs.example.com/api/backups/2022-11-15T0105/apply" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
-> The above command returns JSON structured like this:
-
-```json
-{
-  "backups": [
-    {
-      "id": "2022-11-25T0100",
-      "backupMetadataCovers": true,
-      "backupDirPath": "/metadata/backups",
-      "datePretty": "Fri, Nov 25 2022 01:00",
-      "fullPath": "/metadata/backups/2022-11-25T0100.audiobookshelf",
-      "path": "backups/2022-11-25T0100.audiobookshelf",
-      "filename": "2022-11-25T0100.audiobookshelf",
-      "fileSize": 39819077,
-      "createdAt": 1669366800272,
-      "serverVersion": "2.2.5"
-    }
-  ]
-}
-```
-
-This endpoint retrieves all backups.
+This endpoint applies a backup.
 
 ### HTTP Request
 
-`GET http://abs.example.com/api/backups`
+`GET http://abs.example.com/api/backups/<ID>/apply`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the backup.
 
 ### Response
 
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-403 | Forbidden | An admin user is required to get backups. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`backups` | Array of [Backup](#backup) | The backups on the server.
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | An admin user is required to apply backups.
+404 | Not Found | No backup with the provided ID exists.
 
 
 ## Create a Backup
@@ -163,33 +143,52 @@ Attribute | Type | Description
 --------- | ---- | -----------
 `backups` | Array of [Backup](#backup) | The backups on the server.
 
-
-## Apply a Backup
+## Get All Backups
 
 ```shell
-curl "https://abs.example.com/api/backups/2022-11-15T0105/apply" \
+curl "https://abs.example.com/api/backups" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
-This endpoint applies a backup.
+> The above command returns JSON structured like this:
+
+```json
+{
+  "backups": [
+    {
+      "id": "2022-11-25T0100",
+      "backupMetadataCovers": true,
+      "backupDirPath": "/metadata/backups",
+      "datePretty": "Fri, Nov 25 2022 01:00",
+      "fullPath": "/metadata/backups/2022-11-25T0100.audiobookshelf",
+      "path": "backups/2022-11-25T0100.audiobookshelf",
+      "filename": "2022-11-25T0100.audiobookshelf",
+      "fileSize": 39819077,
+      "createdAt": 1669366800272,
+      "serverVersion": "2.2.5"
+    }
+  ]
+}
+```
+
+This endpoint retrieves all backups.
 
 ### HTTP Request
 
-`GET http://abs.example.com/api/backups/<ID>/apply`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the backup.
+`GET http://abs.example.com/api/backups`
 
 ### Response
 
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | An admin user is required to apply backups.
-404 | Not Found | No backup with the provided ID exists.
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+403 | Forbidden | An admin user is required to get backups. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`backups` | Array of [Backup](#backup) | The backups on the server.
 
 
 ## Upload a Backup

--- a/source/includes/_collections.md
+++ b/source/includes/_collections.md
@@ -1,246 +1,5 @@
 # Collections
 
-## Create a Collection
-
-```shell
-curl -X POST "https://abs.example.com/api/collections" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"libraryId": "lib_c1u6t4p45c35rf0nzd", "name": "Favorites"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "col_fpfstanv6gd7tq2qz7",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "Favorites",
-  "description": null,
-  "cover": null,
-  "coverFullPath": null,
-  "books": [],
-  "lastUpdate": 1650621073750,
-  "createdAt": 1650621073750
-}
-```
-
-This endpoint creates a collection and returns it.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/collections`
-
-### Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`libraryId` | String | **Required** | The ID of the library the collection belongs to.
-`name` | String | **Required** | The name of the collection.
-`description` | String or null | `null` | The collection's description.
-`cover` | String or null | `null` | The path to the collection's cover.
-`coverFullPath` | String or null | `null` | The full path to the collection's cover.
-`books` | Array of String | `[]` | The IDs of book library items that are in the collection.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Collection Expanded](#collection-expanded)
-403 | Forbidden | A user with update permissions is required to create collections. |
-500 | Internal Server Error | `libraryId` and `name` are required parameters. |
-
-
-## Get All Collections
-
-```shell
-curl "https://abs.example.com/api/collections" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "collections": [
-    {
-      "id": "col_fpfstanv6gd7tq2qz7",
-      "libraryId": "lib_c1u6t4p45c35rf0nzd",
-      "userId": "root",
-      "name": "Favorites",
-      "description": null,
-      "cover": null,
-      "coverFullPath": null,
-      "books": [],
-      "lastUpdate": 1650621073750,
-      "createdAt": 1650621073750
-    }
-  ]
-}
-```
-
-This endpoint retrieves all collections.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/collections`
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`collections` | Array of [Collection Expanded](#collection-expanded) | The requested collections.
-
-
-## Get a Collection
-
-```shell
-curl "https://abs.example.com/api/collections/col_fpfstanv6gd7tq2qz7" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "col_fpfstanv6gd7tq2qz7",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "Favorites",
-  "description": null,
-  "cover": null,
-  "coverFullPath": null,
-  "books": [],
-  "lastUpdate": 1650621073750,
-  "createdAt": 1650621073750
-}
-```
-
-This endpoint retrieves a collection.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/collections/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the collection.
-
-### Optional Query Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`include` | String | A comma separated list of what to include with the library item. The only current option is `rssfeed`.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Collection Expanded](#collection-expanded), with extra `rssFeed` attribute (see below) if requested.
-404 | Not Found | No collection with the specified ID exists. |
-
-#### Extra Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`rssFeed` | [RSS Feed Minified](#rss-feed-minified) Object or null | If `rssfeed` was requested, the collection's currently open RSS feed. Will be `null` if the collection does not have an open RSS feed.
-
-
-## Update a Collection
-
-```shell
-curl -X PATCH "https://abs.example.com/api/collections/col_fpfstanv6gd7tq2qz7" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "The Best Books"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "col_fpfstanv6gd7tq2qz7",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "The Best Books",
-  "description": null,
-  "cover": null,
-  "coverFullPath": null,
-  "books": [],
-  "lastUpdate": 1650621110769,
-  "createdAt": 1650621073750
-}
-```
-
-This endpoint updates a collection and returns it.
-
-### HTTP Request
-
-`PATCH http://abs.example.com/api/collections/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the collection.
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`libraryId` | String | The ID of the library the collection belongs to.
-`name` | String | The name of the collection.
-`description` | String or null | The collection's description.
-`cover` | String or null | The path to the collection's cover.
-`coverFullPath` | String or null | The full path to the collection's cover.
-`books` | Array of String | The IDs of book library items that are in the collection.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Collection Expanded](#collection-expanded)
-403 | Forbidden | A user with update permissions is required to update collections. |
-404 | Not Found | No collection with the specified ID exists. |
-
-
-## Delete a Collection
-
-```shell
-curl -X DELETE "https://abs.example.com/api/collections/col_fpfstanv6gd7tq2qz7" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint deletes a collection from the database.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/collections/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the collection.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | A user with delete permissions is required to delete a collection.
-404 | Not Found | No collection with the specified ID exists.
-
-
 ## Add a Book to a Collection
 
 ```shell
@@ -553,52 +312,6 @@ Status | Meaning | Description | Schema
 403 | Forbidden | A user with update permissions is required to update collections. |
 404 | Not Found | No collection with the specified ID exists. |
 500 | Internal Server Error | The provided library item ID could not be found, is in a different library, or is already in the collection. |
-
-
-## Remove a Book From a Collection
-
-```shell
-curl -X DELETE "https://abs.example.com/api/collections/col_fpfstanv6gd7tq2qz7/book/li_8gch9ve09orgn4fdz8" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "col_fpfstanv6gd7tq2qz7",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "Favorites",
-  "description": null,
-  "cover": null,
-  "coverFullPath": null,
-  "books": [],
-  "lastUpdate": 1650621073750,
-  "createdAt": 1650621073750
-}
-```
-
-This endpoint removes a book from a collection and returns the collection.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/collections/<ID>/book/<BookID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the collection.
-BookID | The ID of the book library item to remove from the collection.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Collection Expanded](#collection-expanded)
-403 | Forbidden | A user with delete permissions is required to remove a book from a collection. |
-404 | Not Found | No collection with the specified ID exists. |
 
 
 ## Batch Add Books to a Collection
@@ -967,3 +680,289 @@ Status | Meaning | Description | Schema
 403 | Forbidden | A user with update permissions is required to update collections. |
 404 | Not Found | No collection with the specified ID exists. |
 500 | Internal Server Error | The provided `books` array must not be empty. |
+
+## Create a Collection
+
+```shell
+curl -X POST "https://abs.example.com/api/collections" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"libraryId": "lib_c1u6t4p45c35rf0nzd", "name": "Favorites"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "col_fpfstanv6gd7tq2qz7",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "Favorites",
+  "description": null,
+  "cover": null,
+  "coverFullPath": null,
+  "books": [],
+  "lastUpdate": 1650621073750,
+  "createdAt": 1650621073750
+}
+```
+
+This endpoint creates a collection and returns it.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/collections`
+
+### Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`libraryId` | String | **Required** | The ID of the library the collection belongs to.
+`name` | String | **Required** | The name of the collection.
+`description` | String or null | `null` | The collection's description.
+`cover` | String or null | `null` | The path to the collection's cover.
+`coverFullPath` | String or null | `null` | The full path to the collection's cover.
+`books` | Array of String | `[]` | The IDs of book library items that are in the collection.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Collection Expanded](#collection-expanded)
+403 | Forbidden | A user with update permissions is required to create collections. |
+500 | Internal Server Error | `libraryId` and `name` are required parameters. |
+
+
+## Delete a Collection
+
+```shell
+curl -X DELETE "https://abs.example.com/api/collections/col_fpfstanv6gd7tq2qz7" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint deletes a collection from the database.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/collections/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the collection.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | A user with delete permissions is required to delete a collection.
+404 | Not Found | No collection with the specified ID exists.
+
+
+## Get All Collections
+
+```shell
+curl "https://abs.example.com/api/collections" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "collections": [
+    {
+      "id": "col_fpfstanv6gd7tq2qz7",
+      "libraryId": "lib_c1u6t4p45c35rf0nzd",
+      "userId": "root",
+      "name": "Favorites",
+      "description": null,
+      "cover": null,
+      "coverFullPath": null,
+      "books": [],
+      "lastUpdate": 1650621073750,
+      "createdAt": 1650621073750
+    }
+  ]
+}
+```
+
+This endpoint retrieves all collections.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/collections`
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`collections` | Array of [Collection Expanded](#collection-expanded) | The requested collections.
+
+
+## Get a Collection
+
+```shell
+curl "https://abs.example.com/api/collections/col_fpfstanv6gd7tq2qz7" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "col_fpfstanv6gd7tq2qz7",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "Favorites",
+  "description": null,
+  "cover": null,
+  "coverFullPath": null,
+  "books": [],
+  "lastUpdate": 1650621073750,
+  "createdAt": 1650621073750
+}
+```
+
+This endpoint retrieves a collection.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/collections/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the collection.
+
+### Optional Query Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`include` | String | A comma separated list of what to include with the library item. The only current option is `rssfeed`.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Collection Expanded](#collection-expanded), with extra `rssFeed` attribute (see below) if requested.
+404 | Not Found | No collection with the specified ID exists. |
+
+#### Extra Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`rssFeed` | [RSS Feed Minified](#rss-feed-minified) Object or null | If `rssfeed` was requested, the collection's currently open RSS feed. Will be `null` if the collection does not have an open RSS feed.
+
+
+## Remove a Book From a Collection
+
+```shell
+curl -X DELETE "https://abs.example.com/api/collections/col_fpfstanv6gd7tq2qz7/book/li_8gch9ve09orgn4fdz8" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "col_fpfstanv6gd7tq2qz7",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "Favorites",
+  "description": null,
+  "cover": null,
+  "coverFullPath": null,
+  "books": [],
+  "lastUpdate": 1650621073750,
+  "createdAt": 1650621073750
+}
+```
+
+This endpoint removes a book from a collection and returns the collection.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/collections/<ID>/book/<BookID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the collection.
+BookID | The ID of the book library item to remove from the collection.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Collection Expanded](#collection-expanded)
+403 | Forbidden | A user with delete permissions is required to remove a book from a collection. |
+404 | Not Found | No collection with the specified ID exists. |
+
+
+## Update a Collection
+
+```shell
+curl -X PATCH "https://abs.example.com/api/collections/col_fpfstanv6gd7tq2qz7" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "The Best Books"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "col_fpfstanv6gd7tq2qz7",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "The Best Books",
+  "description": null,
+  "cover": null,
+  "coverFullPath": null,
+  "books": [],
+  "lastUpdate": 1650621110769,
+  "createdAt": 1650621073750
+}
+```
+
+This endpoint updates a collection and returns it.
+
+### HTTP Request
+
+`PATCH http://abs.example.com/api/collections/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the collection.
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`libraryId` | String | The ID of the library the collection belongs to.
+`name` | String | The name of the collection.
+`description` | String or null | The collection's description.
+`cover` | String or null | The path to the collection's cover.
+`coverFullPath` | String or null | The full path to the collection's cover.
+`books` | Array of String | The IDs of book library items that are in the collection.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Collection Expanded](#collection-expanded)
+403 | Forbidden | A user with update permissions is required to update collections. |
+404 | Not Found | No collection with the specified ID exists. |

--- a/source/includes/_items.md
+++ b/source/includes/_items.md
@@ -1,5 +1,425 @@
 # Library Items
 
+## Batch Delete Library Items
+
+```shell
+curl -X POST "https://abs.example.com/api/items/batch/delete" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"libraryItemIds: ["li_bufnnmp4y5o2gbbxfm"]}'
+```
+
+This endpoint batch deletes library items from the database. No files are deleted.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/items/batch/delete`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`libraryItemIds` | Array of String | The IDs of library items to delete.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | The user does not have permission to delete library items.
+404 | Not Found | None of the IDs provided match any library items.
+500 | Internal Server Error | The `libraryItemIds` array must have a non-zero length.
+
+
+## Batch Get Library Items
+
+```shell
+curl -X POST "https://abs.example.com/api/items/batch/get" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"libraryItemIds": ["li_8gch9ve09orgn4fdz8"]}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "libraryItems": [
+    {
+      "id": "li_8gch9ve09orgn4fdz8",
+      "ino": "649641337522215266",
+      "libraryId": "lib_c1u6t4p45c35rf0nzd",
+      "folderId": "fol_bev1zuxhb0j0s1wehr",
+      "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
+      "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
+      "isFile": false,
+      "mtimeMs": 1650621074299,
+      "ctimeMs": 1650621074299,
+      "birthtimeMs": 0,
+      "addedAt": 1650621073750,
+      "updatedAt": 1650621110769,
+      "lastScan": 1651830827825,
+      "scanVersion": "2.0.21",
+      "isMissing": false,
+      "isInvalid": false,
+      "mediaType": "book",
+      "media": {
+        "libraryItemId": "li_8gch9ve09orgn4fdz8",
+        "metadata": {
+          "title": "Wizards First Rule",
+          "titleIgnorePrefix": "Wizards First Rule",
+          "subtitle": null,
+          "authors": [
+            {
+              "id": "aut_z3leimgybl7uf3y4ab",
+              "name": "Terry Goodkind"
+            }
+          ],
+          "narrators": [
+            "Sam Tsoutsouvas"
+          ],
+          "series": [
+            {
+              "id": "ser_cabkj4jeu8be3rap4g",
+              "name": "Sword of Truth",
+              "sequence": "1"
+            }
+          ],
+          "genres": [
+            "Fantasy"
+          ],
+          "publishedYear": "2008",
+          "publishedDate": null,
+          "publisher": "Brilliance Audio",
+          "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+          "isbn": null,
+          "asin": "B002V0QK4C",
+          "language": null,
+          "explicit": false,
+          "authorName": "Terry Goodkind",
+          "authorNameLF": "Goodkind, Terry",
+          "narratorName": "Sam Tsoutsouvas",
+          "seriesName": "Sword of Truth"
+        },
+        "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+        "tags": [
+          "Favorite"
+        ],
+        "audioFiles": [
+          {
+            "index": 1,
+            "ino": "649644248522215260",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "size": 48037888,
+              "mtimeMs": 1632223180278,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621074131,
+            "updatedAt": 1651830828023,
+            "trackNumFromMeta": 1,
+            "discNumFromMeta": null,
+            "trackNumFromFilename": 1,
+            "discNumFromFilename": null,
+            "manuallyVerified": false,
+            "invalid": false,
+            "exclude": false,
+            "error": null,
+            "format": "MP2/3 (MPEG audio layer 2/3)",
+            "duration": 6004.6675,
+            "bitRate": 64000,
+            "language": null,
+            "codec": "mp3",
+            "timeBase": "1/14112000",
+            "channels": 2,
+            "channelLayout": "stereo",
+            "chapters": [],
+            "embeddedCoverArt": null,
+            "metaTags": {
+              "tagAlbum": "SOT Bk01",
+              "tagArtist": "Terry Goodkind",
+              "tagGenre": "Audiobook Fantasy",
+              "tagTitle": "Wizards First Rule 01",
+              "tagTrack": "01/20",
+              "tagAlbumArtist": "Terry Goodkind",
+              "tagComposer": "Terry Goodkind"
+            },
+            "mimeType": "audio/mpeg"
+          },
+          {
+            "index": 2,
+            "ino": "649644248522215261",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "size": 47972352,
+              "mtimeMs": 1632223180281,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621074130,
+            "updatedAt": 1651830828023,
+            "trackNumFromMeta": 2,
+            "discNumFromMeta": null,
+            "trackNumFromFilename": 1,
+            "discNumFromFilename": null,
+            "manuallyVerified": false,
+            "invalid": false,
+            "exclude": false,
+            "error": null,
+            "format": "MP2/3 (MPEG audio layer 2/3)",
+            "duration": 5996.2785,
+            "bitRate": 64000,
+            "language": null,
+            "codec": "mp3",
+            "timeBase": "1/14112000",
+            "channels": 2,
+            "channelLayout": "stereo",
+            "chapters": [],
+            "embeddedCoverArt": null,
+            "metaTags": {
+              "tagAlbum": "SOT Bk01",
+              "tagArtist": "Terry Goodkind",
+              "tagGenre": "Audiobook Fantasy",
+              "tagTitle": "Wizards First Rule 02",
+              "tagTrack": "02/20",
+              "tagAlbumArtist": "Terry Goodkind",
+              "tagComposer": "Terry Goodkind"
+            },
+            "mimeType": "audio/mpeg"
+          }
+        ],
+        "chapters": [
+          {
+            "id": 0,
+            "start": 0,
+            "end": 6004.6675,
+            "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
+          },
+          {
+            "id": 1,
+            "start": 6004.6675,
+            "end": 12000.946,
+            "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
+          }
+        ],
+        "duration": 33854.905,
+        "size": 268824228,
+        "tracks": [
+          {
+            "index": 1,
+            "startOffset": 0,
+            "duration": 6004.6675,
+            "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+            "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+            "mimeType": "audio/mpeg",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "size": 48037888,
+              "mtimeMs": 1632223180278,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            }
+          },
+          {
+            "index": 2,
+            "startOffset": 6004.6675,
+            "duration": 5996.2785,
+            "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+            "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+            "mimeType": "audio/mpeg",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
+              "size": 47972352,
+              "mtimeMs": 1632223180281,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            }
+          }
+        ],
+        "missingParts": [],
+        "ebookFile": null
+      },
+      "libraryFiles": [
+        {
+          "ino": "649644248522215260",
+          "metadata": {
+            "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+            "ext": ".mp3",
+            "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+            "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+            "size": 48037888,
+            "mtimeMs": 1632223180278,
+            "ctimeMs": 1645978261001,
+            "birthtimeMs": 0
+          },
+          "addedAt": 1650621052494,
+          "updatedAt": 1650621052494,
+          "fileType": "audio"
+        },
+        {
+          "ino": "649644248522215261",
+          "metadata": {
+            "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+            "ext": ".mp3",
+            "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+            "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+            "size": 47972352,
+            "mtimeMs": 1632223180281,
+            "ctimeMs": 1645978261001,
+            "birthtimeMs": 0
+          },
+          "addedAt": 1650621052494,
+          "updatedAt": 1650621052494,
+          "fileType": "audio"
+        },
+        {
+          "ino": "649644248522215267",
+          "metadata": {
+            "filename": "cover.jpg",
+            "ext": ".jpg",
+            "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+            "relPath": "cover.jpg",
+            "size": 325531,
+            "mtimeMs": 1638754803540,
+            "ctimeMs": 1645978261003,
+            "birthtimeMs": 0
+          },
+          "addedAt": 1650621052495,
+          "updatedAt": 1650621052495,
+          "fileType": "image"
+        }
+      ],
+      "size": 268990279
+    }
+  ]
+}
+```
+
+This endpoint batch gets library items.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/items/batch/get`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`libraryItemIds` | Array of String | The IDs of library items to get.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+403 | Forbidden | The `libraryItemIds` array must have a non-zero length. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`libraryItems` | Array of [Library Item Expanded](#library-item-expanded) | The requested library items.
+
+
+## Batch Quick Match Library Items
+
+```shell
+curl -X POST "https://abs.example.com/api/items/batch/quickmatch" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"options": {"provider": "openlibrary"}, "libraryItemIds: ["li_8gch9ve09orgn4fdz8"]}'
+```
+
+This endpoint batch matches library items using quick match. Quick match populates empty book details and the cover with the first book result. Does not overwrite existing details unless the "Prefer matched metadata" server setting is enabled or the `overrideDefaults` parameter is `true`.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/items/batch/quickmatch`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`options` | [Options Parameters](#options-parameters) Object (See Below) | The options to use when quick matching.
+`libraryItemIds` | Array of String | The IDs of library items to quick match.
+
+#### Options Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`provider` | String | `google` | The metadata provider to search. See [Metadata Providers](#metadata-providers) for a list of options.
+`overrideDefaults` | Boolean | `false` | Whether to override the existing book details and cover. This will be `true` if the "Prefer matched metadata" server setting is enabled.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | An admin user is required to quick match library items.
+500 | Internal Server Error | The `libraryItemIds` array must have a non-zero length.
+
+## Batch Update Library Items
+
+```shell
+curl -X POST "https://abs.example.com/api/items/batch/update" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '["id": "li_8gch9ve09orgn4fdz8", "mediaPayload": {"metadata": {"title": "Wizards First Rule"}}]'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "success": true,
+  "updates": 1
+}
+```
+
+This endpoint batch updates library items.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/items/batch/update`
+
+### Parameters
+
+Provide an array of objects with the following parameters:
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the library item to update.
+`mediaPayload` | [Book Parameters](#book-parameters) or [Podcast Parameters](#podcast-parameters) | See [Update a Library Item's Media](#update-a-library-item-39-s-media) for details.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+403 | Forbidden | The user does not have permission to update library items. |
+500 | Internal Server Error | The provided array must have a non-zero length. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`success` | Boolean | Whether library items were updated successfully.
+`updates` | Integer | The number library items that were actually changed.
+
+
 ## Delete All Library Items
 
 ```shell
@@ -20,6 +440,32 @@ Status | Meaning | Description
 200 | OK | Success
 403 | Forbidden | An admin user is required to delete all library items.
 500 | Internal Server Error | Something went wrong with recreating the library item database.
+
+
+## Delete a Library Item
+
+```shell
+curl -X DELETE "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint deletes a library item from the database. No files are deleted.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/items/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library item to delete.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
 
 
 ## Get a Library Item
@@ -348,361 +794,6 @@ Attribute | Type | Description
 `episodesDownloading` | Array of [Podcast Episode Download](#podcast-episode-download) | If `downloads` was requested, the podcast episodes currently in the download queue.
 
 
-## Delete a Library Item
-
-```shell
-curl -X DELETE "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint deletes a library item from the database. No files are deleted.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/items/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library item to delete.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-
-
-## Update a Library Item's Media
-
-```shell
-curl -X PATCH "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/media" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"metadata": {"title": "Wizards First Rule"}}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "updated": true,
-  "id": "li_8gch9ve09orgn4fdz8",
-  "ino": "649641337522215266",
-  "libraryId": "main",
-  "folderId": "audiobooks",
-  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
-  "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
-  "isFile": false,
-  "mtimeMs": 1650621074299,
-  "ctimeMs": 1650621074299,
-  "birthtimeMs": 0,
-  "addedAt": 1650621073750,
-  "updatedAt": 1650621110769,
-  "lastScan": 1651830827825,
-  "scanVersion": "2.0.21",
-  "isMissing": false,
-  "isInvalid": false,
-  "mediaType": "book",
-  "media": {
-    "libraryItemId": "li_8gch9ve09orgn4fdz8",
-    "metadata": {
-      "title": "Wizards First Rule",
-      "subtitle": null,
-      "authors": [
-        {
-          "id": "aut_z3leimgybl7uf3y4ab",
-          "name": "Terry Goodkind"
-        }
-      ],
-      "narrators": [
-        "Sam Tsoutsouvas"
-      ],
-      "series": [
-        {
-          "id": "ser_cabkj4jeu8be3rap4g",
-          "name": "Sword of Truth",
-          "sequence": null
-        }
-      ],
-      "genres": [
-        "Fantasy"
-      ],
-      "publishedYear": "2008",
-      "publishedDate": null,
-      "publisher": "Brilliance Audio",
-      "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-      "isbn": null,
-      "asin": "B002V0QK4C",
-      "language": null,
-      "explicit": false
-    },
-    "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-    "tags": [],
-    "audioFiles": [
-      {
-        "index": 1,
-        "ino": "649644248522215260",
-        "metadata": {
-          "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-          "ext": ".mp3",
-          "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-          "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-          "size": 48037888,
-          "mtimeMs": 1632223180278,
-          "ctimeMs": 1645978261001,
-          "birthtimeMs": 0
-        },
-        "addedAt": 1650621074131,
-        "updatedAt": 1651830828023,
-        "trackNumFromMeta": 1,
-        "discNumFromMeta": null,
-        "trackNumFromFilename": 1,
-        "discNumFromFilename": null,
-        "manuallyVerified": false,
-        "invalid": false,
-        "exclude": false,
-        "error": null,
-        "format": "MP2/3 (MPEG audio layer 2/3)",
-        "duration": 6004.6675,
-        "bitRate": 64000,
-        "language": null,
-        "codec": "mp3",
-        "timeBase": "1/14112000",
-        "channels": 2,
-        "channelLayout": "stereo",
-        "chapters": [],
-        "embeddedCoverArt": null,
-        "metaTags": {
-          "tagAlbum": "SOT Bk01",
-          "tagArtist": "Terry Goodkind",
-          "tagGenre": "Audiobook Fantasy",
-          "tagTitle": "Wizards First Rule 01",
-          "tagTrack": "01/20",
-          "tagAlbumArtist": "Terry Goodkind",
-          "tagComposer": "Terry Goodkind"
-        },
-        "mimeType": "audio/mpeg"
-      },
-      {
-        "index": 2,
-        "ino": "649644248522215261",
-        "metadata": {
-          "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-          "ext": ".mp3",
-          "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-          "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-          "size": 47972352,
-          "mtimeMs": 1632223180281,
-          "ctimeMs": 1645978261001,
-          "birthtimeMs": 0
-        },
-        "addedAt": 1650621074130,
-        "updatedAt": 1651830828023,
-        "trackNumFromMeta": 2,
-        "discNumFromMeta": null,
-        "trackNumFromFilename": 1,
-        "discNumFromFilename": null,
-        "manuallyVerified": false,
-        "invalid": false,
-        "exclude": false,
-        "error": null,
-        "format": "MP2/3 (MPEG audio layer 2/3)",
-        "duration": 5996.2785,
-        "bitRate": 64000,
-        "language": null,
-        "codec": "mp3",
-        "timeBase": "1/14112000",
-        "channels": 2,
-        "channelLayout": "stereo",
-        "chapters": [],
-        "embeddedCoverArt": null,
-        "metaTags": {
-          "tagAlbum": "SOT Bk01",
-          "tagArtist": "Terry Goodkind",
-          "tagGenre": "Audiobook Fantasy",
-          "tagTitle": "Wizards First Rule 02",
-          "tagTrack": "02/20",
-          "tagAlbumArtist": "Terry Goodkind",
-          "tagComposer": "Terry Goodkind"
-        },
-        "mimeType": "audio/mpeg"
-      }
-    ],
-    "chapters": [
-      {
-        "id": 0,
-        "start": 0,
-        "end": 6004.6675,
-        "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
-      },
-      {
-        "id": 1,
-        "start": 6004.6675,
-        "end": 12000.946,
-        "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
-      }
-    ],
-    "missingParts": [],
-    "ebookFile": null
-  },
-  "libraryFiles": [
-    {
-      "ino": "649644248522215260",
-      "metadata": {
-        "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-        "ext": ".mp3",
-        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-        "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-        "size": 48037888,
-        "mtimeMs": 1632223180278,
-        "ctimeMs": 1645978261001,
-        "birthtimeMs": 0
-      },
-      "addedAt": 1650621052494,
-      "updatedAt": 1650621052494,
-      "fileType": "audio"
-    },
-    {
-      "ino": "649644248522215261",
-      "metadata": {
-        "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-        "ext": ".mp3",
-        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-        "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-        "size": 47972352,
-        "mtimeMs": 1632223180281,
-        "ctimeMs": 1645978261001,
-        "birthtimeMs": 0
-      },
-      "addedAt": 1650621052494,
-      "updatedAt": 1650621052494,
-      "fileType": "audio"
-    },
-    {
-      "ino": "649644248522215267",
-      "metadata": {
-        "filename": "cover.jpg",
-        "ext": ".jpg",
-        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-        "relPath": "cover.jpg",
-        "size": 325531,
-        "mtimeMs": 1638754803540,
-        "ctimeMs": 1645978261003,
-        "birthtimeMs": 0
-      },
-      "addedAt": 1650621052495,
-      "updatedAt": 1650621052495,
-      "fileType": "image"
-    }
-  ]
-}
-```
-
-This endpoint updates a library item's media and returns the updated library item.
-
-### HTTP Request
-
-`PATCH http://abs.example.com/api/items/<ID>/media`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library item.
-
-### Parameters
-
-A library item's media can be either [Book Parameters](#book-parameters) or [Podcast Parameters](#podcast-parameters) (see below). Check the library item's `mediaType` before updating it.
-
-#### Book Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`metadata` | [Book Metadata](#book-metadata-parameters) Object (See Below) | The book's metadata.
-`coverPath` | String or null | The absolute path on the server of the cover file. Use `null` to remove the cover. Prefer using the [Update a Library Item's Cover](#update-a-library-item-39-s-cover) endpoint.
-`tags` | Array of String | The book's tags.
-`chapters` | Array of [Book Chapter](#book-chapter-parameters) | The book's chapters. Prefer using the [Update a Library Item's Chapters](#update-a-library-item-39-s-chapters) endpoint.
-
-#### Book Metadata Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`title` | String or null | The title of the book.
-`subtitle` | String or null | The subtitle of the book.
-`authors` | Array of [Author](#author-parameters) (See Below) | The authors of the book.
-`narrators` | Array of String | The narrators of the book.
-`series` | Array of [Series Sequence](#series-parameters) (See Below) | The series the book belongs to.
-`genres` | Array of String | The genres of the book.
-`publishedYear` | String or null | The year the book was published.
-`publishedDate` | String or null | The date the book was published.
-`publisher` | String or null | The publisher of the book.
-`description` | String or null | A description of the book.
-`isbn` | String or null | The ISBN of the book.
-`asin` | String or null | The ASIN of the book.
-`language` | String or null | The language of the book.
-`explicit` | Boolean | Whether to mark the book as explicit.
-
-#### Author Parameters
-
-The server will automatically find the ID of the author or create one.
-
-Parameter | Type | Description
---------- | ---- | -----------
-`name` | String | The name of the author.
-
-#### Series Parameters
-
-The server will automatically find the ID of the series or create one.
-
-Parameter | Type | Description
---------- | ---- | -----------
-`name` | String | The name of the series.
-`sequence` | String or null | The position in the series the book is.
-
-#### Podcast Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`metadata` | [Podcast Metadata](#podcast-metadata-parameters) Object (See Below) | The podcast's metadata.
-`coverPath` | String or null | The absolute path on the server of the cover file. Use `null` to remove the cover. Prefer using the [Update a Library Item's Cover](#update-a-library-item-39-s-cover) endpoint.
-`tags` | Array of String | The podcast's tags.
-`autoDownloadEpisodes` | Boolean | Whether the server will automatically download podcast episodes according to the schedule.
-`autoDownloadSchedule` | String or null | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to automatically download podcast episodes.
-`lastEpisodeCheck` | Integer | The time (in ms since POSIX epoch) when the podcast was checked for new episodes.
-`maxEpisodesToKeep` | Integer | The maximum number of podcast episodes to keep when automatically downloading new episodes. Episodes beyond this limit will be deleted. If `0`, all episodes will be kept.
-`maxNewEpisodesToDownload` | Integer | The maximum number of podcast episodes to download when automatically downloading new episodes. If `0`, all episodes will be downloaded.
-
-<aside class="notice">
-Use the <a href="#update-a-podcast-episode">Update a Podcast Episode</a> endpoint to update a podcast's episodes.
-</aside>
-
-#### Podcast Metadata Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`title` | String or null | The title of the podcast.
-`author` | String or null | The author of the podcast.
-`description` | String or null | The description of the podcast.
-`releaseDate` | String or null | The release date of the podcast.
-`genres` | Array of String | The podcast's genres.
-`feedUrl` | String or null | A URL of an RSS feed for the podcast.
-`imageUrl` | String or null | A URL of a cover image for the podcast.
-`itunesPageUrl` | String or null | A URL of an iTunes page for the podcast.
-`itunesId` | Integer or null | The iTunes ID for the podcast.
-`itunesArtistId` | Integer or null | The iTunes Artist ID for the author of the podcast.
-`explicit` | Boolean | Whether to mark the podcast as explicit.
-`language` | String or null | The language of the podcast.
-`type` | String | The type of the podcast. Should be `episodic` or `serial`.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Library Item](#library-item) with an `updated` attribute, a Boolean, whether anything was actually changed.
-
-
 ## Get a Library Item's Cover
 
 ```shell
@@ -743,151 +834,80 @@ Status | Meaning | Description
 500 | Internal Server Error | There was an error when attempting to read the cover file.
 
 
-## Upload a Library Item Cover
-
-> Upload a cover image:
+## Get a Library Item's Tone Metadata Object
 
 ```shell
-curl -X POST "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/cover" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -F cover=@cover.jpg
-```
-
-> Or download a cover image from a URL:
-
-```shell
-curl -X POST "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/cover" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://m.media-amazon.com/images/I/51xUwj8eKVL._SL500_.jpg"}'
-```
-
-> The above commands return JSON structured like this:
-
-```json
-{
-  "success": true,
-  "cover": "/metadata/items/li_8gch9ve09orgn4fdz8/cover.jpg"
-}
-```
-
-This endpoint uploads a cover for a library item or requests the server to download a cover from a specified URL.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/items/<ID>/cover`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library item.
-
-### Form Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`cover` | Image Binary Data | The cover to upload.
-
-### JSON Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`url` | String | The URL to download the cover from.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-400 | Bad Request | The request did not contain a file or URL.
-403 | Forbidden | The user does not have permission to upload.
-500 | Internal Server Error | Unknown error.
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`success` | Boolean | Whether the upload was successful.
-`cover` | String | The full path of the cover on the server.
-
-
-## Update a Library Item's Cover
-
-```shell
-curl -X PATCH "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/cover" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"cover": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg"}'
+curl "https://abs.example.com/api/items/li_bufnnmp4y5o2gbbxfm/tone-object" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
 > The above command returns JSON structured like this:
 
 ```json
 {
-  "success": true,
-  "cover": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg"
+  "Title": "Wizards First Rule",
+  "Album": "Wizards First Rule",
+  "TrackTotal": 2,
+  "Artist": "Terry Goodkind",
+  "AlbumArtist": "Terry Goodkind",
+  "Comment": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+  "Description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+  "Narrator": "Sam Tsoutsouvas",
+  "Composer": "Sam Tsoutsouvas",
+  "MovementName": "Sword of Truth",
+  "Movement": "1",
+  "Genre": "Fantasy",
+  "Publisher": "Brilliance Audio",
+  "CoverFile": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+  "PublishingDate": "01/01/2008",
+  "AdditionalFields": [
+    "ASIN=B002V0QK4C"
+  ]
 }
 ```
 
-This endpoint updates a library item's cover with an image already on the server.
+This endpoint returns a library item's tone metadata object.
 
 ### HTTP Request
 
-`PATCH http://abs.example.com/api/items/<ID>/cover`
+`GET http://abs.example.com/api/items/<ID>/tone-object`
 
 ### URL Parameters
 
 Parameter | Description
 --------- | -----------
 ID | The ID of the library item.
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`cover` | String | The absolute path of the image on the server to change the library item's cover to.
 
 ### Response
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
 200 | OK | Success | See below.
-400 | Bad Request | The `cover` parameter is required.
-500 | Internal Server Error | Either the submitted path is invalid, does not exist, is not an image, or the server failed to copy the image to the library item's directory.
+403 | Forbidden | An admin user is required to get a library item's tone metadata object. |
+500 | Internal Server Error | The library item has missing parts, does not have audio files, or is not a book. |
 
 #### Response Schema
 
+Book metadata that is `null` will not exist in the response object, except for the title which will be replaced by an empty string.
+
 Attribute | Type | Description
 --------- | ---- | -----------
-`success` | Boolean | Whether the cover was updated successfully.
-`cover` | String | The absolute path on the server of the library item's cover.
-
-
-## Remove a Library Item's Cover
-
-```shell
-curl -X DELETE "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/cover" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint removes a library item's cover.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/items/<ID>/cover`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library item.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
+`Title` | String | The book's title.
+`Album` | String | The book's title.
+`TrackTotal` | Integer | The number of audio tracks for the book.
+`Artist` | String | The book's author.
+`AlbumArtist` | String | The book's author.
+`Comment` | String | The book's description.
+`Description` | String | The book's description.
+`Narrator` | String | The book's narrators.
+`Composer` | String | The book's narrators.
+`MovementName` | String | The book's first series.
+`Movement` | String | The sequence of the book in its first series.
+`Genre` | String | All of the book's genres `/` separated.
+`Publisher` | String | The book's publisher.
+`CoverFile` | String | The book's cover path.
+`PublishingDate` | String | January 1st of the book's published year.
+`AdditionalFields` | Array of String | Additional metadata fields. Those are currently ASIN and ISBN.
 
 
 ## Match a Library Item
@@ -1493,6 +1513,176 @@ Status | Meaning | Description | Schema
 404 | Not Found | The library item does not have any audio tracks to play. |
 
 
+## Remove a Library Item's Cover
+
+```shell
+curl -X DELETE "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/cover" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint removes a library item's cover.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/items/<ID>/cover`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library item.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+
+
+## Scan a Library Item
+
+```shell
+curl -X POST "https://abs.example.com/api/items/li_bufnnmp4y5o2gbbxfm/scan" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "result": "UPDATED"
+}
+```
+
+This endpoint scans a library item's files for changes.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/items/<ID>/scan`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library item.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+403 | Forbidden | An admin user is required to scan a library item. |
+500 | Internal Server Error | Rescanning file library items is not yet supported. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`result` | String | The result of the scan operation. Can be `NOTHING`, `ADDED`, `UPDATED`, `REMOVED`, or `UPTODATE`.
+
+
+## Tone Scan a Library Item
+
+```shell
+curl -X POST "https://abs.example.com/api/items/li_bufnnmp4y5o2gbbxfm/tone-scan/1" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "audio": {
+    "bitrate": 64,
+    "format": "MPEG Audio (Layer III)",
+    "formatShort": "MPEG",
+    "sampleRate": 22050,
+    "duration": 6004667,
+    "channels": {
+      "count": 2,
+      "description": "Joint Stereo"
+    },
+    "frames": {
+      "offset": 3857,
+      "length": 66381321
+    },
+    "metaFormat": [
+      "id3V23",
+      "id3V1"
+    ]
+  },
+  "meta": {
+    "album": "Sword of Truth",
+    "albumArtist": "Terry Goodkind",
+    "artist": "Terry Goodkind",
+    "composer": "Sam Tsoutsouvas",
+    "comment": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+    "encoderSettings": "LAME 32bits version 3.99.5 (http://lame.sf.net)",
+    "genre": "Fantasy",
+    "recordingDate": "2008-01-01T00:00:00",
+    "title": "Wizards First Rule",
+    "trackNumber": 1,
+    "additionalFields": {
+      "ufid": "FID",
+      "narratedby": "ARRATEDBY",
+      "woas": "OAS"
+    }
+  },
+  "file": {
+    "size": 48037888,
+    "created": "2022-04-22T09:51:14.299+00:00",
+    "modified": "2022-04-22T09:51:14.299+00:00",
+    "accessed": "2022-04-22T09:51:14.299+00:00",
+    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
+    "name": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3"
+  }
+}
+```
+
+This endpoint uses [tone](https://github.com/sandreas/tone) to scan a library item and returns the results.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/items/<ID>/tone-scan/<Index?>`
+
+### URL Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+ID | String | **Required** | The ID of the library item.
+Index | Integer | `1` | The index of the audio file to tone scan.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+404 | Not Found | The library does not have any audio files to scan or the requested audio file index does not exist. |
+
+#### Response Schema
+
+See [tone](https://github.com/sandreas/tone) for details.
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`audio.bitrate` | Integer | The bitrate of the audio file.
+`audio.format` | String | The format of the audio file.
+`audio.formatShort` | String | The short format of the audio file.
+`audio.duration` | Integer | The duration (in ms) of the audio file.
+`audio.channels.count` | Integer | The number of audio channels in the audio file.
+`audio.channels.description` | String | The description of the channel setup of the audio file.
+`audio.frames.offset` | Integer | The frame offset of the audio file.
+`audio.frames.length` | Integer | The frame length of the audio file.
+`audio.metaFormat` | Array of String | The metadata formats of the audio file.
+`meta` | Object | The metadata tags of the audio file.
+`file.size` | Integer | The size (in bytes) of the audio file.
+`file.created` | String | When the audio file was created.
+`file.modified` | String | When the audio file was last modified.
+`file.accessed` | String | When the audio file was last accessed.
+`file.path` | String | The parent path of the audio file.
+`file.name` | String | The filename of the audio file.
+
+
 ## Update a Library Item's Audio Tracks
 
 ```shell
@@ -1755,124 +1945,6 @@ Status | Meaning | Description | Schema
 500 | Internal Server Error | The library item's media type must be `book` for this endpoint.
 
 
-## Scan a Library Item
-
-```shell
-curl -X POST "https://abs.example.com/api/items/li_bufnnmp4y5o2gbbxfm/scan" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "result": "UPDATED"
-}
-```
-
-This endpoint scans a library item's files for changes.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/items/<ID>/scan`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library item.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-403 | Forbidden | An admin user is required to scan a library item. |
-500 | Internal Server Error | Rescanning file library items is not yet supported. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`result` | String | The result of the scan operation. Can be `NOTHING`, `ADDED`, `UPDATED`, `REMOVED`, or `UPTODATE`.
-
-
-## Get a Library Item's Tone Metadata Object
-
-```shell
-curl "https://abs.example.com/api/items/li_bufnnmp4y5o2gbbxfm/tone-object" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "Title": "Wizards First Rule",
-  "Album": "Wizards First Rule",
-  "TrackTotal": 2,
-  "Artist": "Terry Goodkind",
-  "AlbumArtist": "Terry Goodkind",
-  "Comment": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-  "Description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-  "Narrator": "Sam Tsoutsouvas",
-  "Composer": "Sam Tsoutsouvas",
-  "MovementName": "Sword of Truth",
-  "Movement": "1",
-  "Genre": "Fantasy",
-  "Publisher": "Brilliance Audio",
-  "CoverFile": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-  "PublishingDate": "01/01/2008",
-  "AdditionalFields": [
-    "ASIN=B002V0QK4C"
-  ]
-}
-```
-
-This endpoint returns a library item's tone metadata object.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/items/<ID>/tone-object`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library item.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-403 | Forbidden | An admin user is required to get a library item's tone metadata object. |
-500 | Internal Server Error | The library item has missing parts, does not have audio files, or is not a book. |
-
-#### Response Schema
-
-Book metadata that is `null` will not exist in the response object, except for the title which will be replaced by an empty string.
-
-Attribute | Type | Description
---------- | ---- | -----------
-`Title` | String | The book's title.
-`Album` | String | The book's title.
-`TrackTotal` | Integer | The number of audio tracks for the book.
-`Artist` | String | The book's author.
-`AlbumArtist` | String | The book's author.
-`Comment` | String | The book's description.
-`Description` | String | The book's description.
-`Narrator` | String | The book's narrators.
-`Composer` | String | The book's narrators.
-`MovementName` | String | The book's first series.
-`Movement` | String | The sequence of the book in its first series.
-`Genre` | String | All of the book's genres `/` separated.
-`Publisher` | String | The book's publisher.
-`CoverFile` | String | The book's cover path.
-`PublishingDate` | String | January 1st of the book's published year.
-`AdditionalFields` | Array of String | Additional metadata fields. Those are currently ASIN and ISBN.
-
-
 ## Update a Library Item's Chapters
 
 ```shell
@@ -1926,146 +1998,13 @@ Attribute | Type | Description
 `updated` | Boolean | Whether the book's chapters were actually changed.
 
 
-## Tone Scan a Library Item
+## Update a Library Item's Cover
 
 ```shell
-curl -X POST "https://abs.example.com/api/items/li_bufnnmp4y5o2gbbxfm/tone-scan/1" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "audio": {
-    "bitrate": 64,
-    "format": "MPEG Audio (Layer III)",
-    "formatShort": "MPEG",
-    "sampleRate": 22050,
-    "duration": 6004667,
-    "channels": {
-      "count": 2,
-      "description": "Joint Stereo"
-    },
-    "frames": {
-      "offset": 3857,
-      "length": 66381321
-    },
-    "metaFormat": [
-      "id3V23",
-      "id3V1"
-    ]
-  },
-  "meta": {
-    "album": "Sword of Truth",
-    "albumArtist": "Terry Goodkind",
-    "artist": "Terry Goodkind",
-    "composer": "Sam Tsoutsouvas",
-    "comment": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-    "encoderSettings": "LAME 32bits version 3.99.5 (http://lame.sf.net)",
-    "genre": "Fantasy",
-    "recordingDate": "2008-01-01T00:00:00",
-    "title": "Wizards First Rule",
-    "trackNumber": 1,
-    "additionalFields": {
-      "ufid": "FID",
-      "narratedby": "ARRATEDBY",
-      "woas": "OAS"
-    }
-  },
-  "file": {
-    "size": 48037888,
-    "created": "2022-04-22T09:51:14.299+00:00",
-    "modified": "2022-04-22T09:51:14.299+00:00",
-    "accessed": "2022-04-22T09:51:14.299+00:00",
-    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
-    "name": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3"
-  }
-}
-```
-
-This endpoint uses [tone](https://github.com/sandreas/tone) to scan a library item and returns the results.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/items/<ID>/tone-scan/<Index?>`
-
-### URL Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-ID | String | **Required** | The ID of the library item.
-Index | Integer | `1` | The index of the audio file to tone scan.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-404 | Not Found | The library does not have any audio files to scan or the requested audio file index does not exist. |
-
-#### Response Schema
-
-See [tone](https://github.com/sandreas/tone) for details.
-
-Attribute | Type | Description
---------- | ---- | -----------
-`audio.bitrate` | Integer | The bitrate of the audio file.
-`audio.format` | String | The format of the audio file.
-`audio.formatShort` | String | The short format of the audio file.
-`audio.duration` | Integer | The duration (in ms) of the audio file.
-`audio.channels.count` | Integer | The number of audio channels in the audio file.
-`audio.channels.description` | String | The description of the channel setup of the audio file.
-`audio.frames.offset` | Integer | The frame offset of the audio file.
-`audio.frames.length` | Integer | The frame length of the audio file.
-`audio.metaFormat` | Array of String | The metadata formats of the audio file.
-`meta` | Object | The metadata tags of the audio file.
-`file.size` | Integer | The size (in bytes) of the audio file.
-`file.created` | String | When the audio file was created.
-`file.modified` | String | When the audio file was last modified.
-`file.accessed` | String | When the audio file was last accessed.
-`file.path` | String | The parent path of the audio file.
-`file.name` | String | The filename of the audio file.
-
-
-## Batch Delete Library Items
-
-```shell
-curl -X POST "https://abs.example.com/api/items/batch/delete" \
+curl -X PATCH "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/cover" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
   -H "Content-Type: application/json" \
-  -d '{"libraryItemIds: ["li_bufnnmp4y5o2gbbxfm"]}'
-```
-
-This endpoint batch deletes library items from the database. No files are deleted.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/items/batch/delete`
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`libraryItemIds` | Array of String | The IDs of library items to delete.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | The user does not have permission to delete library items.
-404 | Not Found | None of the IDs provided match any library items.
-500 | Internal Server Error | The `libraryItemIds` array must have a non-zero length.
-
-
-## Batch Update Library Items
-
-```shell
-curl -X POST "https://abs.example.com/api/items/batch/update" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '["id": "li_8gch9ve09orgn4fdz8", "mediaPayload": {"metadata": {"title": "Wizards First Rule"}}]'
+  -d '{"cover": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg"}'
 ```
 
 > The above command returns JSON structured like this:
@@ -2073,377 +2012,437 @@ curl -X POST "https://abs.example.com/api/items/batch/update" \
 ```json
 {
   "success": true,
-  "updates": 1
+  "cover": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg"
 }
 ```
 
-This endpoint batch updates library items.
+This endpoint updates a library item's cover with an image already on the server.
 
 ### HTTP Request
 
-`POST http://abs.example.com/api/items/batch/update`
+`PATCH http://abs.example.com/api/items/<ID>/cover`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library item.
 
 ### Parameters
 
-Provide an array of objects with the following parameters:
-
 Parameter | Type | Description
 --------- | ---- | -----------
-`id` | String | The ID of the library item to update.
-`mediaPayload` | [Book Parameters](#book-parameters) or [Podcast Parameters](#podcast-parameters) | See [Update a Library Item's Media](#update-a-library-item-39-s-media) for details.
+`cover` | String | The absolute path of the image on the server to change the library item's cover to.
 
 ### Response
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
 200 | OK | Success | See below.
-403 | Forbidden | The user does not have permission to update library items. |
-500 | Internal Server Error | The provided array must have a non-zero length. |
+400 | Bad Request | The `cover` parameter is required.
+500 | Internal Server Error | Either the submitted path is invalid, does not exist, is not an image, or the server failed to copy the image to the library item's directory.
 
 #### Response Schema
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`success` | Boolean | Whether library items were updated successfully.
-`updates` | Integer | The number library items that were actually changed.
+`success` | Boolean | Whether the cover was updated successfully.
+`cover` | String | The absolute path on the server of the library item's cover.
 
 
-## Batch Get Library Items
+## Update a Library Item's Media
 
 ```shell
-curl -X POST "https://abs.example.com/api/items/batch/get" \
+curl -X PATCH "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/media" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
   -H "Content-Type: application/json" \
-  -d '{"libraryItemIds": ["li_8gch9ve09orgn4fdz8"]}'
+  -d '{"metadata": {"title": "Wizards First Rule"}}'
 ```
 
 > The above command returns JSON structured like this:
 
 ```json
 {
-  "libraryItems": [
-    {
-      "id": "li_8gch9ve09orgn4fdz8",
-      "ino": "649641337522215266",
-      "libraryId": "lib_c1u6t4p45c35rf0nzd",
-      "folderId": "fol_bev1zuxhb0j0s1wehr",
-      "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
-      "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
-      "isFile": false,
-      "mtimeMs": 1650621074299,
-      "ctimeMs": 1650621074299,
-      "birthtimeMs": 0,
-      "addedAt": 1650621073750,
-      "updatedAt": 1650621110769,
-      "lastScan": 1651830827825,
-      "scanVersion": "2.0.21",
-      "isMissing": false,
-      "isInvalid": false,
-      "mediaType": "book",
-      "media": {
-        "libraryItemId": "li_8gch9ve09orgn4fdz8",
-        "metadata": {
-          "title": "Wizards First Rule",
-          "titleIgnorePrefix": "Wizards First Rule",
-          "subtitle": null,
-          "authors": [
-            {
-              "id": "aut_z3leimgybl7uf3y4ab",
-              "name": "Terry Goodkind"
-            }
-          ],
-          "narrators": [
-            "Sam Tsoutsouvas"
-          ],
-          "series": [
-            {
-              "id": "ser_cabkj4jeu8be3rap4g",
-              "name": "Sword of Truth",
-              "sequence": "1"
-            }
-          ],
-          "genres": [
-            "Fantasy"
-          ],
-          "publishedYear": "2008",
-          "publishedDate": null,
-          "publisher": "Brilliance Audio",
-          "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-          "isbn": null,
-          "asin": "B002V0QK4C",
-          "language": null,
-          "explicit": false,
-          "authorName": "Terry Goodkind",
-          "authorNameLF": "Goodkind, Terry",
-          "narratorName": "Sam Tsoutsouvas",
-          "seriesName": "Sword of Truth"
-        },
-        "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-        "tags": [
-          "Favorite"
-        ],
-        "audioFiles": [
-          {
-            "index": 1,
-            "ino": "649644248522215260",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "size": 48037888,
-              "mtimeMs": 1632223180278,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621074131,
-            "updatedAt": 1651830828023,
-            "trackNumFromMeta": 1,
-            "discNumFromMeta": null,
-            "trackNumFromFilename": 1,
-            "discNumFromFilename": null,
-            "manuallyVerified": false,
-            "invalid": false,
-            "exclude": false,
-            "error": null,
-            "format": "MP2/3 (MPEG audio layer 2/3)",
-            "duration": 6004.6675,
-            "bitRate": 64000,
-            "language": null,
-            "codec": "mp3",
-            "timeBase": "1/14112000",
-            "channels": 2,
-            "channelLayout": "stereo",
-            "chapters": [],
-            "embeddedCoverArt": null,
-            "metaTags": {
-              "tagAlbum": "SOT Bk01",
-              "tagArtist": "Terry Goodkind",
-              "tagGenre": "Audiobook Fantasy",
-              "tagTitle": "Wizards First Rule 01",
-              "tagTrack": "01/20",
-              "tagAlbumArtist": "Terry Goodkind",
-              "tagComposer": "Terry Goodkind"
-            },
-            "mimeType": "audio/mpeg"
-          },
-          {
-            "index": 2,
-            "ino": "649644248522215261",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "size": 47972352,
-              "mtimeMs": 1632223180281,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621074130,
-            "updatedAt": 1651830828023,
-            "trackNumFromMeta": 2,
-            "discNumFromMeta": null,
-            "trackNumFromFilename": 1,
-            "discNumFromFilename": null,
-            "manuallyVerified": false,
-            "invalid": false,
-            "exclude": false,
-            "error": null,
-            "format": "MP2/3 (MPEG audio layer 2/3)",
-            "duration": 5996.2785,
-            "bitRate": 64000,
-            "language": null,
-            "codec": "mp3",
-            "timeBase": "1/14112000",
-            "channels": 2,
-            "channelLayout": "stereo",
-            "chapters": [],
-            "embeddedCoverArt": null,
-            "metaTags": {
-              "tagAlbum": "SOT Bk01",
-              "tagArtist": "Terry Goodkind",
-              "tagGenre": "Audiobook Fantasy",
-              "tagTitle": "Wizards First Rule 02",
-              "tagTrack": "02/20",
-              "tagAlbumArtist": "Terry Goodkind",
-              "tagComposer": "Terry Goodkind"
-            },
-            "mimeType": "audio/mpeg"
-          }
-        ],
-        "chapters": [
-          {
-            "id": 0,
-            "start": 0,
-            "end": 6004.6675,
-            "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
-          },
-          {
-            "id": 1,
-            "start": 6004.6675,
-            "end": 12000.946,
-            "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
-          }
-        ],
-        "duration": 33854.905,
-        "size": 268824228,
-        "tracks": [
-          {
-            "index": 1,
-            "startOffset": 0,
-            "duration": 6004.6675,
-            "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-            "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-            "mimeType": "audio/mpeg",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "size": 48037888,
-              "mtimeMs": 1632223180278,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            }
-          },
-          {
-            "index": 2,
-            "startOffset": 6004.6675,
-            "duration": 5996.2785,
-            "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-            "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-            "mimeType": "audio/mpeg",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
-              "size": 47972352,
-              "mtimeMs": 1632223180281,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            }
-          }
-        ],
-        "missingParts": [],
-        "ebookFile": null
-      },
-      "libraryFiles": [
+  "updated": true,
+  "id": "li_8gch9ve09orgn4fdz8",
+  "ino": "649641337522215266",
+  "libraryId": "main",
+  "folderId": "audiobooks",
+  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
+  "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
+  "isFile": false,
+  "mtimeMs": 1650621074299,
+  "ctimeMs": 1650621074299,
+  "birthtimeMs": 0,
+  "addedAt": 1650621073750,
+  "updatedAt": 1650621110769,
+  "lastScan": 1651830827825,
+  "scanVersion": "2.0.21",
+  "isMissing": false,
+  "isInvalid": false,
+  "mediaType": "book",
+  "media": {
+    "libraryItemId": "li_8gch9ve09orgn4fdz8",
+    "metadata": {
+      "title": "Wizards First Rule",
+      "subtitle": null,
+      "authors": [
         {
-          "ino": "649644248522215260",
-          "metadata": {
-            "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-            "ext": ".mp3",
-            "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-            "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-            "size": 48037888,
-            "mtimeMs": 1632223180278,
-            "ctimeMs": 1645978261001,
-            "birthtimeMs": 0
-          },
-          "addedAt": 1650621052494,
-          "updatedAt": 1650621052494,
-          "fileType": "audio"
-        },
-        {
-          "ino": "649644248522215261",
-          "metadata": {
-            "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-            "ext": ".mp3",
-            "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-            "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-            "size": 47972352,
-            "mtimeMs": 1632223180281,
-            "ctimeMs": 1645978261001,
-            "birthtimeMs": 0
-          },
-          "addedAt": 1650621052494,
-          "updatedAt": 1650621052494,
-          "fileType": "audio"
-        },
-        {
-          "ino": "649644248522215267",
-          "metadata": {
-            "filename": "cover.jpg",
-            "ext": ".jpg",
-            "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-            "relPath": "cover.jpg",
-            "size": 325531,
-            "mtimeMs": 1638754803540,
-            "ctimeMs": 1645978261003,
-            "birthtimeMs": 0
-          },
-          "addedAt": 1650621052495,
-          "updatedAt": 1650621052495,
-          "fileType": "image"
+          "id": "aut_z3leimgybl7uf3y4ab",
+          "name": "Terry Goodkind"
         }
       ],
-      "size": 268990279
+      "narrators": [
+        "Sam Tsoutsouvas"
+      ],
+      "series": [
+        {
+          "id": "ser_cabkj4jeu8be3rap4g",
+          "name": "Sword of Truth",
+          "sequence": null
+        }
+      ],
+      "genres": [
+        "Fantasy"
+      ],
+      "publishedYear": "2008",
+      "publishedDate": null,
+      "publisher": "Brilliance Audio",
+      "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+      "isbn": null,
+      "asin": "B002V0QK4C",
+      "language": null,
+      "explicit": false
+    },
+    "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+    "tags": [],
+    "audioFiles": [
+      {
+        "index": 1,
+        "ino": "649644248522215260",
+        "metadata": {
+          "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+          "ext": ".mp3",
+          "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+          "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+          "size": 48037888,
+          "mtimeMs": 1632223180278,
+          "ctimeMs": 1645978261001,
+          "birthtimeMs": 0
+        },
+        "addedAt": 1650621074131,
+        "updatedAt": 1651830828023,
+        "trackNumFromMeta": 1,
+        "discNumFromMeta": null,
+        "trackNumFromFilename": 1,
+        "discNumFromFilename": null,
+        "manuallyVerified": false,
+        "invalid": false,
+        "exclude": false,
+        "error": null,
+        "format": "MP2/3 (MPEG audio layer 2/3)",
+        "duration": 6004.6675,
+        "bitRate": 64000,
+        "language": null,
+        "codec": "mp3",
+        "timeBase": "1/14112000",
+        "channels": 2,
+        "channelLayout": "stereo",
+        "chapters": [],
+        "embeddedCoverArt": null,
+        "metaTags": {
+          "tagAlbum": "SOT Bk01",
+          "tagArtist": "Terry Goodkind",
+          "tagGenre": "Audiobook Fantasy",
+          "tagTitle": "Wizards First Rule 01",
+          "tagTrack": "01/20",
+          "tagAlbumArtist": "Terry Goodkind",
+          "tagComposer": "Terry Goodkind"
+        },
+        "mimeType": "audio/mpeg"
+      },
+      {
+        "index": 2,
+        "ino": "649644248522215261",
+        "metadata": {
+          "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+          "ext": ".mp3",
+          "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+          "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+          "size": 47972352,
+          "mtimeMs": 1632223180281,
+          "ctimeMs": 1645978261001,
+          "birthtimeMs": 0
+        },
+        "addedAt": 1650621074130,
+        "updatedAt": 1651830828023,
+        "trackNumFromMeta": 2,
+        "discNumFromMeta": null,
+        "trackNumFromFilename": 1,
+        "discNumFromFilename": null,
+        "manuallyVerified": false,
+        "invalid": false,
+        "exclude": false,
+        "error": null,
+        "format": "MP2/3 (MPEG audio layer 2/3)",
+        "duration": 5996.2785,
+        "bitRate": 64000,
+        "language": null,
+        "codec": "mp3",
+        "timeBase": "1/14112000",
+        "channels": 2,
+        "channelLayout": "stereo",
+        "chapters": [],
+        "embeddedCoverArt": null,
+        "metaTags": {
+          "tagAlbum": "SOT Bk01",
+          "tagArtist": "Terry Goodkind",
+          "tagGenre": "Audiobook Fantasy",
+          "tagTitle": "Wizards First Rule 02",
+          "tagTrack": "02/20",
+          "tagAlbumArtist": "Terry Goodkind",
+          "tagComposer": "Terry Goodkind"
+        },
+        "mimeType": "audio/mpeg"
+      }
+    ],
+    "chapters": [
+      {
+        "id": 0,
+        "start": 0,
+        "end": 6004.6675,
+        "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
+      },
+      {
+        "id": 1,
+        "start": 6004.6675,
+        "end": 12000.946,
+        "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
+      }
+    ],
+    "missingParts": [],
+    "ebookFile": null
+  },
+  "libraryFiles": [
+    {
+      "ino": "649644248522215260",
+      "metadata": {
+        "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+        "ext": ".mp3",
+        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+        "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+        "size": 48037888,
+        "mtimeMs": 1632223180278,
+        "ctimeMs": 1645978261001,
+        "birthtimeMs": 0
+      },
+      "addedAt": 1650621052494,
+      "updatedAt": 1650621052494,
+      "fileType": "audio"
+    },
+    {
+      "ino": "649644248522215261",
+      "metadata": {
+        "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+        "ext": ".mp3",
+        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+        "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+        "size": 47972352,
+        "mtimeMs": 1632223180281,
+        "ctimeMs": 1645978261001,
+        "birthtimeMs": 0
+      },
+      "addedAt": 1650621052494,
+      "updatedAt": 1650621052494,
+      "fileType": "audio"
+    },
+    {
+      "ino": "649644248522215267",
+      "metadata": {
+        "filename": "cover.jpg",
+        "ext": ".jpg",
+        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+        "relPath": "cover.jpg",
+        "size": 325531,
+        "mtimeMs": 1638754803540,
+        "ctimeMs": 1645978261003,
+        "birthtimeMs": 0
+      },
+      "addedAt": 1650621052495,
+      "updatedAt": 1650621052495,
+      "fileType": "image"
     }
   ]
 }
 ```
 
-This endpoint batch gets library items.
+This endpoint updates a library item's media and returns the updated library item.
 
 ### HTTP Request
 
-`POST http://abs.example.com/api/items/batch/get`
+`PATCH http://abs.example.com/api/items/<ID>/media`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library item.
 
 ### Parameters
 
+A library item's media can be either [Book Parameters](#book-parameters) or [Podcast Parameters](#podcast-parameters) (see below). Check the library item's `mediaType` before updating it.
+
+#### Book Parameters
+
 Parameter | Type | Description
 --------- | ---- | -----------
-`libraryItemIds` | Array of String | The IDs of library items to get.
+`metadata` | [Book Metadata](#book-metadata-parameters) Object (See Below) | The book's metadata.
+`coverPath` | String or null | The absolute path on the server of the cover file. Use `null` to remove the cover. Prefer using the [Update a Library Item's Cover](#update-a-library-item-39-s-cover) endpoint.
+`tags` | Array of String | The book's tags.
+`chapters` | Array of [Book Chapter](#book-chapter-parameters) | The book's chapters. Prefer using the [Update a Library Item's Chapters](#update-a-library-item-39-s-chapters) endpoint.
+
+#### Book Metadata Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`title` | String or null | The title of the book.
+`subtitle` | String or null | The subtitle of the book.
+`authors` | Array of [Author](#author-parameters) (See Below) | The authors of the book.
+`narrators` | Array of String | The narrators of the book.
+`series` | Array of [Series Sequence](#series-parameters) (See Below) | The series the book belongs to.
+`genres` | Array of String | The genres of the book.
+`publishedYear` | String or null | The year the book was published.
+`publishedDate` | String or null | The date the book was published.
+`publisher` | String or null | The publisher of the book.
+`description` | String or null | A description of the book.
+`isbn` | String or null | The ISBN of the book.
+`asin` | String or null | The ASIN of the book.
+`language` | String or null | The language of the book.
+`explicit` | Boolean | Whether to mark the book as explicit.
+
+#### Author Parameters
+
+The server will automatically find the ID of the author or create one.
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`name` | String | The name of the author.
+
+#### Series Parameters
+
+The server will automatically find the ID of the series or create one.
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`name` | String | The name of the series.
+`sequence` | String or null | The position in the series the book is.
+
+#### Podcast Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`metadata` | [Podcast Metadata](#podcast-metadata-parameters) Object (See Below) | The podcast's metadata.
+`coverPath` | String or null | The absolute path on the server of the cover file. Use `null` to remove the cover. Prefer using the [Update a Library Item's Cover](#update-a-library-item-39-s-cover) endpoint.
+`tags` | Array of String | The podcast's tags.
+`autoDownloadEpisodes` | Boolean | Whether the server will automatically download podcast episodes according to the schedule.
+`autoDownloadSchedule` | String or null | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to automatically download podcast episodes.
+`lastEpisodeCheck` | Integer | The time (in ms since POSIX epoch) when the podcast was checked for new episodes.
+`maxEpisodesToKeep` | Integer | The maximum number of podcast episodes to keep when automatically downloading new episodes. Episodes beyond this limit will be deleted. If `0`, all episodes will be kept.
+`maxNewEpisodesToDownload` | Integer | The maximum number of podcast episodes to download when automatically downloading new episodes. If `0`, all episodes will be downloaded.
+
+<aside class="notice">
+Use the <a href="#update-a-podcast-episode">Update a Podcast Episode</a> endpoint to update a podcast's episodes.
+</aside>
+
+#### Podcast Metadata Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`title` | String or null | The title of the podcast.
+`author` | String or null | The author of the podcast.
+`description` | String or null | The description of the podcast.
+`releaseDate` | String or null | The release date of the podcast.
+`genres` | Array of String | The podcast's genres.
+`feedUrl` | String or null | A URL of an RSS feed for the podcast.
+`imageUrl` | String or null | A URL of a cover image for the podcast.
+`itunesPageUrl` | String or null | A URL of an iTunes page for the podcast.
+`itunesId` | Integer or null | The iTunes ID for the podcast.
+`itunesArtistId` | Integer or null | The iTunes Artist ID for the author of the podcast.
+`explicit` | Boolean | Whether to mark the podcast as explicit.
+`language` | String or null | The language of the podcast.
+`type` | String | The type of the podcast. Should be `episodic` or `serial`.
 
 ### Response
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
-200 | OK | Success | See Below
-403 | Forbidden | The `libraryItemIds` array must have a non-zero length. |
+200 | OK | Success | [Library Item](#library-item) with an `updated` attribute, a Boolean, whether anything was actually changed.
+
+
+## Upload a Library Item Cover
+
+> Upload a cover image:
+
+```shell
+curl -X POST "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/cover" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -F cover=@cover.jpg
+```
+
+> Or download a cover image from a URL:
+
+```shell
+curl -X POST "https://abs.example.com/api/items/li_8gch9ve09orgn4fdz8/cover" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://m.media-amazon.com/images/I/51xUwj8eKVL._SL500_.jpg"}'
+```
+
+> The above commands return JSON structured like this:
+
+```json
+{
+  "success": true,
+  "cover": "/metadata/items/li_8gch9ve09orgn4fdz8/cover.jpg"
+}
+```
+
+This endpoint uploads a cover for a library item or requests the server to download a cover from a specified URL.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/items/<ID>/cover`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library item.
+
+### Form Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`cover` | Image Binary Data | The cover to upload.
+
+### JSON Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`url` | String | The URL to download the cover from.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+400 | Bad Request | The request did not contain a file or URL.
+403 | Forbidden | The user does not have permission to upload.
+500 | Internal Server Error | Unknown error.
 
 #### Response Schema
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`libraryItems` | Array of [Library Item Expanded](#library-item-expanded) | The requested library items.
-
-
-## Batch Quick Match Library Items
-
-```shell
-curl -X POST "https://abs.example.com/api/items/batch/quickmatch" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"options": {"provider": "openlibrary"}, "libraryItemIds: ["li_8gch9ve09orgn4fdz8"]}'
-```
-
-This endpoint batch matches library items using quick match. Quick match populates empty book details and the cover with the first book result. Does not overwrite existing details unless the "Prefer matched metadata" server setting is enabled or the `overrideDefaults` parameter is `true`.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/items/batch/quickmatch`
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`options` | [Options Parameters](#options-parameters) Object (See Below) | The options to use when quick matching.
-`libraryItemIds` | Array of String | The IDs of library items to quick match.
-
-#### Options Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`provider` | String | `google` | The metadata provider to search. See [Metadata Providers](#metadata-providers) for a list of options.
-`overrideDefaults` | Boolean | `false` | Whether to override the existing book details and cover. This will be `true` if the "Prefer matched metadata" server setting is enabled.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | An admin user is required to quick match library items.
-500 | Internal Server Error | The `libraryItemIds` array must have a non-zero length.
+`success` | Boolean | Whether the upload was successful.
+`cover` | String | The full path of the cover on the server.

--- a/source/includes/_libraries.md
+++ b/source/includes/_libraries.md
@@ -73,6 +73,65 @@ Status | Meaning | Description | Schema
 200 | OK | Success | [Library](#library)
 
 
+## Delete a Library
+
+```shell
+curl -X DELETE "https://abs.example.com/api/libraries/lib_5yvub9dqvctlcrza6h" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> If successful the deleted library will be returned like this:
+
+```json
+{
+  "id": "lib_5yvub9dqvctlcrza6h",
+  "name": "audiobooks",
+  "folders": [
+    {
+      "id": "fol_zdat63120karrt7i52",
+      "fullPath": "/audiobooks",
+      "libraryId": "lib_5yvub9dqvctlcrza6g",
+      "addedAt": 1653396692539
+    }
+  ],
+  "displayOrder": 5,
+  "icon": "database",
+  "mediaType": "book",
+  "provider": "audible",
+  "settings": {
+    "coverAspectRatio": 1,
+    "disableWatcher": false,
+    "skipMatchingMediaWithAsin": false,
+    "skipMatchingMediaWithIsbn": false,
+    "autoScanCronExpression": null
+  },
+  "createdAt": 1653396692539,
+  "lastUpdate": 1653396692539
+}
+```
+
+This endpoint deletes a library.
+
+### HTTP Request
+
+`DELETE https://abs.example.com/api/libraries/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library to delete.
+
+<aside class="notice">Deleting a library will remove all library items including any user progress for those items.</aside>
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Library](#library)
+404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
+
+
 ## Get All Libraries
 
 ```shell
@@ -255,151 +314,10 @@ Attribute | Type | Description
 `library` | [Library](#library) Object | The requested library.
 
 
-## Update a Library
+## Get a Library's Authors
 
 ```shell
-curl -X PATCH "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json"
-  -d '{"name": "Pods", "icon": "podcast"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "lib_c1u6t4p45c35rf0nzd",
-  "name": "Pods",
-  "folders": [
-    {
-      "id": "fol_bev1zuxhb0j0s1wehr",
-      "fullPath": "/podcasts",
-      "libraryId": "lib_c1u6t4p45c35rf0nzd",
-      "addedAt": 1650462940610
-    }
-  ],
-  "displayOrder": 4,
-  "icon": "podcast",
-  "mediaType": "podcast",
-  "provider": "itunes",
-  "settings": {
-    "coverAspectRatio": 1,
-    "disableWatcher": false,
-    "skipMatchingMediaWithAsin": false,
-    "skipMatchingMediaWithIsbn": false,
-    "autoScanCronExpression": null
-  },
-  "createdAt": 1650462940610,
-  "lastUpdate": 1655423464567
-}
-```
-
-This endpoint updates a library.
-
-### HTTP Request
-
-`PATCH https://abs.example.com/api/libraries/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library to update.
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`name` | String | The name of the library.
-`folders` | Array of [Folder](#folder) | See the notice below. Only specify the `fullPath` for new folders.
-`displayOrder` | Integer | Display position of the library in the list of libraries. Must be `>= 1`.
-`icon` | String | The icon of the library. See [Library Icons](#library-icons) for a list of possible icons.
-`provider` | String | Preferred metadata provider for the library. See [Metadata Providers](#metadata-providers) for a list of possible providers.
-`settings` | [Library Settings](#library-settings) Object | The settings for the library.
-
-#### Library Settings Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`coverAspectRatio` | Integer | Whether the library should use square book covers. Must be `0` (for false) or `1` (for true).
-`disableWatcher` | Boolean | Whether to disable the folder watcher for the library.
-`skipMatchingMediaWithAsin` | Boolean | Whether to skip matching books that already have an ASIN.
-`skipMatchingMediaWithIsbn` | Boolean | Whether to skip matching books that already have an ISBN.
-`autoScanCronExpression` | String or null | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to automatically scan the library folders. If `null`, automatic scanning will be disabled.
-
-<aside class="notice">When updating folders you must pass in the full array of folders. Any missing folders from the array will be removed. New folders must not have an <code>id</code> set because this will be set automatically.</aside>
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Library](#library)
-404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
-
-
-## Delete a Library
-
-```shell
-curl -X DELETE "https://abs.example.com/api/libraries/lib_5yvub9dqvctlcrza6h" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> If successful the deleted library will be returned like this:
-
-```json
-{
-  "id": "lib_5yvub9dqvctlcrza6h",
-  "name": "audiobooks",
-  "folders": [
-    {
-      "id": "fol_zdat63120karrt7i52",
-      "fullPath": "/audiobooks",
-      "libraryId": "lib_5yvub9dqvctlcrza6g",
-      "addedAt": 1653396692539
-    }
-  ],
-  "displayOrder": 5,
-  "icon": "database",
-  "mediaType": "book",
-  "provider": "audible",
-  "settings": {
-    "coverAspectRatio": 1,
-    "disableWatcher": false,
-    "skipMatchingMediaWithAsin": false,
-    "skipMatchingMediaWithIsbn": false,
-    "autoScanCronExpression": null
-  },
-  "createdAt": 1653396692539,
-  "lastUpdate": 1653396692539
-}
-```
-
-This endpoint deletes a library.
-
-### HTTP Request
-
-`DELETE https://abs.example.com/api/libraries/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library to delete.
-
-<aside class="notice">Deleting a library will remove all library items including any user progress for those items.</aside>
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Library](#library)
-404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
-
-
-## Get a Library's Items
-
-```shell
-curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/items?sort=media.metadata.title&filter=authors.YXV0X3ozbGVpbWd5Ymw3dWYzeTRhYg%3D%3D&collapseseries=1" \
+curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/authors" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
@@ -407,101 +325,32 @@ curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/items?sort=me
 
 ```json
 {
-  "results": [
+  "authors": [
     {
-      "id": "li_8gch9ve09orgn4fdz8",
-      "ino": "649641337522215266",
-      "libraryId": "main",
-      "folderId": "audiobooks",
-      "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
-      "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
-      "isFile": false,
-      "mtimeMs": 1650621074299,
-      "ctimeMs": 1650621074299,
-      "birthtimeMs": 0,
+      "id": "aut_z3leimgybl7uf3y4ab",
+      "asin": null,
+      "name": "Terry Goodkind",
+      "description": null,
+      "imagePath": null,
       "addedAt": 1650621073750,
-      "updatedAt": 1650621110769,
-      "isMissing": false,
-      "isInvalid": false,
-      "mediaType": "book",
-      "media": {
-        "metadata": {
-          "title": "Wizards First Rule",
-          "titleIgnorePrefix": "Wizards First Rule",
-          "subtitle": null,
-          "authorName": "Terry Goodkind",
-          "narratorName": "Sam Tsoutsouvas",
-          "seriesName": "Sword of Truth",
-          "genres": [
-            "Fantasy"
-          ],
-          "publishedYear": "2008",
-          "publishedDate": null,
-          "publisher": "Brilliance Audio",
-          "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-          "isbn": null,
-          "asin": "B002V0QK4C",
-          "language": null,
-          "explicit": false
-        },
-        "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-        "tags": [],
-        "numTracks": 2,
-        "numAudioFiles": 2,
-        "numChapters": 2,
-        "numMissingParts": 0,
-        "numInvalidAudioFiles": 0,
-        "duration": 12000.946,
-        "size": 96010240,
-        "ebookFileFormat": null
-      },
-      "numFiles": 3,
-      "size": 96335771,
-      "collapsedSeries": {
-        "id": "ser_cabkj4jeu8be3rap4g",
-        "name": "Sword of Truth",
-        "nameIgnorePrefix": "Sword of Truth",
-        "numBooks": 1
-      }
+      "updatedAt": 1650621073750,
+      "numBooks": 1
     }
-  ],
-  "total": 1,
-  "limit": 0,
-  "page": 0,
-  "sortBy": "media.metadata.title",
-  "sortDesc": false,
-  "filterBy": "authors.YXV0X3ozbGVpbWd5Ymw3dWYzeTRhYg==",
-  "mediaType": "book",
-  "minified": false,
-  "collapseseries": true,
-  "include": ""
+  ]
 }
 ```
 
-This endpoint returns a library's items, optionally sorted and/or filtered.
+This endpoint returns a library's authors.
 
 ### HTTP Request
 
-`GET https://abs.example.com/api/libraries/<ID>/items`
+`GET https://abs.example.com/api/libraries/<ID>/authors`
 
 ### URL Parameters
 
 Parameter | Description
 --------- | -----------
 ID | The ID of the library.
-
-### Optional Query Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`limit` | Integer | Limit the number of returned results per page. If `0`, no limit will be applied.
-`page` | Integer | The page number (0 indexed) to request. If there is no limit applied, then page will have no effect and all results will be returned.
-`sort` | String | What to sort the results by. Specify the attribute to sort by using JavaScript object notation. For example, to sort by title use `sort=media.metadata.title`. When filtering for a series, sort can also be `sequence`.
-`desc` | Binary | Whether to reverse the sort order. `0` for false, `1` for true.
-`filter` | String | What to filter the results by. See [Filtering](#filtering).
-`minified` | Binary | Whether to request minified objects. `0` for false, `1` for true.
-`collapseseries` | Binary | Whether to collapse books in a series to a single entry. `0` for false, `1` for true.
-`include` | String | A comma separated list of what to include with the library items. The only current option is `rssfeed`.
 
 ### Response
 
@@ -514,238 +363,7 @@ Status | Meaning | Description | Schema
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`results` | Array of [Library Item](#library-item) | The requested library items. If `minified` is `true`, it will be an array of [Library Item Minified](#library-item-minified). `collapseseries` will add a [Series Num Books](#series-num-books) as `collapsedSeries` to the library items, with only one library item per series. However, if there is only one series in the results, they will not be collapsed. When filtering by series, `media.metadata.series` will be replaced by the matching [Series Sequence](#series-sequence) object. If filtering by series, `collapseseries` is `true`, and there are multiple series, such as a subseries, a `seriesSequenceList` string attribute is added to `collapsedSeries` which represents the items in the subseries that are in the filtered series. `rssfeed` will add an [RSS Feed Minified](#rss-feed-minified) object or `null` as `rssFeed` to the library items, the item's RSS feed if it has one open.
-`total` | Integer | The total number of results.
-`limit` | Integer | The limit set in the request.
-`page` | Integer | The page set in request.
-`sortBy` | String | The sort set in the request. Will not exist if no sort was set.
-`sortDesc` | Boolean | Whether to reverse the sort order.
-`filterBy` | String | The filter set in the request, URL decoded. Will not exist if no filter was set.
-`mediaType` | String | The media type of the library. Will be `book` or `podcast`.
-`minified` | Boolean | Whether minified was set in the request.
-`collapseseries` | Boolean | Whether collapseseries was set in the request.
-`include` | String | The requested `include`.
-
-
-## Remove a Library's Items With Issues
-
-```shell
-curl -X DELETE "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/issues" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint removes a library's items that have issues.
-
-### HTTP Request
-
-`DELETE https://abs.example.com/api/libraries/<ID>/issues`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-404 | Not Found | The user cannot access the library, or no library with the provided ID exists.
-
-
-## Get a Library's Podcast Episode Downloads
-
-```shell
-curl "https://abs.example.com/api/libraries/lib_p9wkw2i85qy9oltijt/episode-downloads" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "currentDownload": {
-    "id": "epdl_pgv4d47j6dtqpk4r0v",
-    "episodeDisplayTitle": "2 - Glow Cloud",
-    "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/cb1dd91f-5d8d-42e9-ba22-14ff335d2cbb/2_Glow_Cloud.mp3",
-    "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-    "libraryId": "lib_p9wkw2i85qy9oltijt",
-    "isFinished": false,
-    "failed": false,
-    "startedAt": null,
-    "createdAt": 1668122813409,
-    "finishedAt": null,
-    "podcastTitle": "Welcome to Night Vale",
-    "podcastExplicit": false,
-    "season": "",
-    "episode": "",
-    "episodeType": "full",
-    "publishedAt": 1341144000000
-  },
-  "queue": []
-}
-```
-
-This endpoint retrieves the podcast episodes downloads of the library.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/libraries/<ID>/episode-downloads`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-404 | Not Found | No library with the given ID exists, or the user cannot access it. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`currentDownload` | [Podcast Episode Download](#podcast-episode-download) Object | The podcast episode currently being downloaded. Will only exist if an episode download is in progress.
-`queue` | Array of [Podcast Episode Download](#podcast-episode-download) | The podcast episodes in the queue to be downloaded.
-
-
-## Get a Library's Series
-
-```shell
-curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/series?minified=1" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "results": [
-    {
-      "id": "ser_cabkj4jeu8be3rap4g",
-      "name": "Sword of Truth",
-      "nameIgnorePrefix": "Sword of Truth",
-      "nameIgnorePrefixSort": "Sword of Truth",
-      "type": "series",
-      "books": [
-        {
-          "id": "li_8gch9ve09orgn4fdz8",
-          "ino": "649641337522215266",
-          "libraryId": "main",
-          "folderId": "audiobooks",
-          "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
-          "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
-          "isFile": false,
-          "mtimeMs": 1650621074299,
-          "ctimeMs": 1650621074299,
-          "birthtimeMs": 0,
-          "addedAt": 1650621073750,
-          "updatedAt": 1650621110769,
-          "isMissing": false,
-          "isInvalid": false,
-          "mediaType": "book",
-          "media": {
-            "metadata": {
-              "title": "Wizards First Rule",
-              "titleIgnorePrefix": "Wizards First Rule",
-              "subtitle": null,
-              "authorName": "Terry Goodkind",
-              "narratorName": "Sam Tsoutsouvas",
-              "seriesName": "Sword of Truth",
-              "genres": [
-                "Fantasy"
-              ],
-              "publishedYear": "2008",
-              "publishedDate": null,
-              "publisher": "Brilliance Audio",
-              "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-              "isbn": null,
-              "asin": "B002V0QK4C",
-              "language": null,
-              "explicit": false
-            },
-            "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-            "tags": [],
-            "numTracks": 2,
-            "numAudioFiles": 2,
-            "numChapters": 2,
-            "numMissingParts": 0,
-            "numInvalidAudioFiles": 0,
-            "duration": 12000.946,
-            "size": 96010240,
-            "ebookFileFormat": null
-          },
-          "numFiles": 3,
-          "size": 96335771,
-          "sequence": "1"
-        }
-      ],
-      "addedAt": 1650621073750,
-      "totalDuration": 12000.946
-    }
-  ],
-  "total": 1,
-  "limit": 0,
-  "page": 0,
-  "sortBy": "media.metadata.title",
-  "sortDesc": false,
-  "filterBy": "authors.YXV0X3ozbGVpbWd5Ymw3dWYzeTRhYg==",
-  "mediaType": "book",
-  "minified": false,
-  "collapseseries": true,
-  "include": ""
-}
-```
-
-This endpoint returns a library's series.
-
-### HTTP Request
-
-`GET https://abs.example.com/api/libraries/<ID>/series`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library.
-
-### Optional Query Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`limit` | Integer | Limit the number of returned results per page. If `0`, no limit will be applied.
-`page` | Integer | The page number (0 indexed) to request. If there is no limit applied, then page will have no effect and all results will be returned.
-`sort` | String | What to sort the results by. By default, the results will be sorted by series name. Other sort options are: numBooks, totalDuration, and addedAt.
-`desc` | Binary | Whether to reverse the sort order. `0` for false, `1` for true.
-`filter` | String | What to filter the results by. See [Filtering](#filtering). The `issues` and `feed-open` filters are not available for this endpoint.
-`minified` | Binary | Whether to request minified objects. `0` for `false`, `1` for `true`.
-`include` | String | A comma separated list of what to include with the library items. The only current option is `rssfeed`.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`results` | Array of [Series Books](#series-books) | The requested series. If `minified` is `true`, the library items contained in the series will be [Library Item Minified](#library-item-minified). If `rssfeed` was requested, an [RSS Feed Minified](#rss-feed-minified) object or `null` as `rssFeed`, the series' RSS feed if it has one open, will be added to the series.
-`total` | Integer | The total number of results.
-`limit` | Integer | The limit set in the request.
-`page` | Integer | The page set in request.
-`sortBy` | String | The sort set in the request. Will not exist if no sort was set.
-`sortDesc` | Boolean | Whether to reverse the sort order.
-`filterBy` | String | The filter set in the request, URL decoded. Will not exist if no filter was set.
-`minified` | Boolean | Whether minified was set in the request.
-`include` | String | The requested `include`.
+`authors` | Array of [Author Expanded](#author-expanded) | The requested authors.
 
 
 ## Get a Library's Collections
@@ -882,10 +500,64 @@ Attribute | Type | Description
 `include` | String | The requested `include`.
 
 
-## Get a Library's User Playlists
+## Get a Library's Filter Data
 
 ```shell
-curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/playlists" \
+curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/filterdata" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "authors": [
+    {
+      "id": "aut_z3leimgybl7uf3y4ab",
+      "name": "Terry Goodkind"
+    }
+  ],
+  "genres": [
+    "Fantasy"
+  ],
+  "tags": [],
+  "series": [
+    {
+      "id": "ser_cabkj4jeu8be3rap4g",
+      "name": "Sword of Truth"
+    }
+  ],
+  "narrators": [
+    "Sam Tsoutsouvas"
+  ],
+  "languages": []
+}
+```
+
+This endpoint returns a library's filter data that can be used for displaying a filter list.
+
+### HTTP Request
+
+`GET https://abs.example.com/api/libraries/<ID>/filterdata`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Library Filter Data](#library-filter-data)
+404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
+
+
+## Get a Library's Items
+
+```shell
+curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/items?sort=media.metadata.title&filter=authors.YXV0X3ozbGVpbWd5Ymw3dWYzeTRhYg%3D%3D&collapseseries=1" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
@@ -895,292 +567,80 @@ curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/playlists" \
 {
   "results": [
     {
-      "id": "pl_qbwet64998s5ra6dcu",
-      "libraryId": "lib_c1u6t4p45c35rf0nzd",
-      "userId": "root",
-      "name": "Favorites",
-      "description": null,
-      "coverPath": null,
-      "items": [
-        {
-          "libraryItemId": "li_8gch9ve09orgn4fdz8",
-          "episodeId": null,
-          "libraryItem": {
-            "id": "li_8gch9ve09orgn4fdz8",
-            "ino": "649641337522215266",
-            "libraryId": "lib_c1u6t4p45c35rf0nzd",
-            "folderId": "fol_bev1zuxhb0j0s1wehr",
-            "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
-            "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
-            "isFile": false,
-            "mtimeMs": 1650621074299,
-            "ctimeMs": 1650621074299,
-            "birthtimeMs": 0,
-            "addedAt": 1650621073750,
-            "updatedAt": 1650621110769,
-            "lastScan": 1651830827825,
-            "scanVersion": "2.0.21",
-            "isMissing": false,
-            "isInvalid": false,
-            "mediaType": "book",
-            "media": {
-              "libraryItemId": "li_8gch9ve09orgn4fdz8",
-              "metadata": {
-                "title": "Wizards First Rule",
-                "titleIgnorePrefix": "Wizards First Rule",
-                "subtitle": null,
-                "authors": [
-                  {
-                    "id": "aut_z3leimgybl7uf3y4ab",
-                    "name": "Terry Goodkind"
-                  }
-                ],
-                "narrators": [
-                  "Sam Tsoutsouvas"
-                ],
-                "series": [
-                  {
-                    "id": "ser_cabkj4jeu8be3rap4g",
-                    "name": "Sword of Truth",
-                    "sequence": "1"
-                  }
-                ],
-                "genres": [
-                  "Fantasy"
-                ],
-                "publishedYear": "2008",
-                "publishedDate": null,
-                "publisher": "Brilliance Audio",
-                "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-                "isbn": null,
-                "asin": "B002V0QK4C",
-                "language": null,
-                "explicit": false,
-                "authorName": "Terry Goodkind",
-                "authorNameLF": "Goodkind, Terry",
-                "narratorName": "Sam Tsoutsouvas",
-                "seriesName": "Sword of Truth"
-              },
-              "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-              "tags": [
-                "Favorite"
-              ],
-              "audioFiles": [
-                {
-                  "index": 1,
-                  "ino": "649644248522215260",
-                  "metadata": {
-                    "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                    "ext": ".mp3",
-                    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                    "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                    "size": 48037888,
-                    "mtimeMs": 1632223180278,
-                    "ctimeMs": 1645978261001,
-                    "birthtimeMs": 0
-                  },
-                  "addedAt": 1650621074131,
-                  "updatedAt": 1651830828023,
-                  "trackNumFromMeta": 1,
-                  "discNumFromMeta": null,
-                  "trackNumFromFilename": 1,
-                  "discNumFromFilename": null,
-                  "manuallyVerified": false,
-                  "invalid": false,
-                  "exclude": false,
-                  "error": null,
-                  "format": "MP2/3 (MPEG audio layer 2/3)",
-                  "duration": 6004.6675,
-                  "bitRate": 64000,
-                  "language": null,
-                  "codec": "mp3",
-                  "timeBase": "1/14112000",
-                  "channels": 2,
-                  "channelLayout": "stereo",
-                  "chapters": [],
-                  "embeddedCoverArt": null,
-                  "metaTags": {
-                    "tagAlbum": "SOT Bk01",
-                    "tagArtist": "Terry Goodkind",
-                    "tagGenre": "Audiobook Fantasy",
-                    "tagTitle": "Wizards First Rule 01",
-                    "tagTrack": "01/20",
-                    "tagAlbumArtist": "Terry Goodkind",
-                    "tagComposer": "Terry Goodkind"
-                  },
-                  "mimeType": "audio/mpeg"
-                },
-                {
-                  "index": 2,
-                  "ino": "649644248522215261",
-                  "metadata": {
-                    "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                    "ext": ".mp3",
-                    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                    "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                    "size": 47972352,
-                    "mtimeMs": 1632223180281,
-                    "ctimeMs": 1645978261001,
-                    "birthtimeMs": 0
-                  },
-                  "addedAt": 1650621074130,
-                  "updatedAt": 1651830828023,
-                  "trackNumFromMeta": 2,
-                  "discNumFromMeta": null,
-                  "trackNumFromFilename": 1,
-                  "discNumFromFilename": null,
-                  "manuallyVerified": false,
-                  "invalid": false,
-                  "exclude": false,
-                  "error": null,
-                  "format": "MP2/3 (MPEG audio layer 2/3)",
-                  "duration": 5996.2785,
-                  "bitRate": 64000,
-                  "language": null,
-                  "codec": "mp3",
-                  "timeBase": "1/14112000",
-                  "channels": 2,
-                  "channelLayout": "stereo",
-                  "chapters": [],
-                  "embeddedCoverArt": null,
-                  "metaTags": {
-                    "tagAlbum": "SOT Bk01",
-                    "tagArtist": "Terry Goodkind",
-                    "tagGenre": "Audiobook Fantasy",
-                    "tagTitle": "Wizards First Rule 02",
-                    "tagTrack": "02/20",
-                    "tagAlbumArtist": "Terry Goodkind",
-                    "tagComposer": "Terry Goodkind"
-                  },
-                  "mimeType": "audio/mpeg"
-                }
-              ],
-              "chapters": [
-                {
-                  "id": 0,
-                  "start": 0,
-                  "end": 6004.6675,
-                  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
-                },
-                {
-                  "id": 1,
-                  "start": 6004.6675,
-                  "end": 12000.946,
-                  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
-                }
-              ],
-              "duration": 33854.905,
-              "size": 268824228,
-              "tracks": [
-                {
-                  "index": 1,
-                  "startOffset": 0,
-                  "duration": 6004.6675,
-                  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                  "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                  "mimeType": "audio/mpeg",
-                  "metadata": {
-                    "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                    "ext": ".mp3",
-                    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                    "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                    "size": 48037888,
-                    "mtimeMs": 1632223180278,
-                    "ctimeMs": 1645978261001,
-                    "birthtimeMs": 0
-                  }
-                },
-                {
-                  "index": 2,
-                  "startOffset": 6004.6675,
-                  "duration": 5996.2785,
-                  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                  "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                  "mimeType": "audio/mpeg",
-                  "metadata": {
-                    "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                    "ext": ".mp3",
-                    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                    "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
-                    "size": 47972352,
-                    "mtimeMs": 1632223180281,
-                    "ctimeMs": 1645978261001,
-                    "birthtimeMs": 0
-                  }
-                }
-              ],
-              "missingParts": [],
-              "ebookFile": null
-            },
-            "libraryFiles": [
-              {
-                "ino": "649644248522215260",
-                "metadata": {
-                  "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                  "ext": ".mp3",
-                  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                  "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                  "size": 48037888,
-                  "mtimeMs": 1632223180278,
-                  "ctimeMs": 1645978261001,
-                  "birthtimeMs": 0
-                },
-                "addedAt": 1650621052494,
-                "updatedAt": 1650621052494,
-                "fileType": "audio"
-              },
-              {
-                "ino": "649644248522215261",
-                "metadata": {
-                  "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                  "ext": ".mp3",
-                  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                  "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                  "size": 47972352,
-                  "mtimeMs": 1632223180281,
-                  "ctimeMs": 1645978261001,
-                  "birthtimeMs": 0
-                },
-                "addedAt": 1650621052494,
-                "updatedAt": 1650621052494,
-                "fileType": "audio"
-              },
-              {
-                "ino": "649644248522215267",
-                "metadata": {
-                  "filename": "cover.jpg",
-                  "ext": ".jpg",
-                  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-                  "relPath": "cover.jpg",
-                  "size": 325531,
-                  "mtimeMs": 1638754803540,
-                  "ctimeMs": 1645978261003,
-                  "birthtimeMs": 0
-                },
-                "addedAt": 1650621052495,
-                "updatedAt": 1650621052495,
-                "fileType": "image"
-              }
-            ],
-            "size": 268990279
-          }
-        }
-      ],
-      "lastUpdate": 1669623431313,
-      "createdAt": 1669623431313
+      "id": "li_8gch9ve09orgn4fdz8",
+      "ino": "649641337522215266",
+      "libraryId": "main",
+      "folderId": "audiobooks",
+      "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
+      "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
+      "isFile": false,
+      "mtimeMs": 1650621074299,
+      "ctimeMs": 1650621074299,
+      "birthtimeMs": 0,
+      "addedAt": 1650621073750,
+      "updatedAt": 1650621110769,
+      "isMissing": false,
+      "isInvalid": false,
+      "mediaType": "book",
+      "media": {
+        "metadata": {
+          "title": "Wizards First Rule",
+          "titleIgnorePrefix": "Wizards First Rule",
+          "subtitle": null,
+          "authorName": "Terry Goodkind",
+          "narratorName": "Sam Tsoutsouvas",
+          "seriesName": "Sword of Truth",
+          "genres": [
+            "Fantasy"
+          ],
+          "publishedYear": "2008",
+          "publishedDate": null,
+          "publisher": "Brilliance Audio",
+          "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+          "isbn": null,
+          "asin": "B002V0QK4C",
+          "language": null,
+          "explicit": false
+        },
+        "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+        "tags": [],
+        "numTracks": 2,
+        "numAudioFiles": 2,
+        "numChapters": 2,
+        "numMissingParts": 0,
+        "numInvalidAudioFiles": 0,
+        "duration": 12000.946,
+        "size": 96010240,
+        "ebookFileFormat": null
+      },
+      "numFiles": 3,
+      "size": 96335771,
+      "collapsedSeries": {
+        "id": "ser_cabkj4jeu8be3rap4g",
+        "name": "Sword of Truth",
+        "nameIgnorePrefix": "Sword of Truth",
+        "numBooks": 1
+      }
     }
   ],
   "total": 1,
   "limit": 0,
-  "page": 0
+  "page": 0,
+  "sortBy": "media.metadata.title",
+  "sortDesc": false,
+  "filterBy": "authors.YXV0X3ozbGVpbWd5Ymw3dWYzeTRhYg==",
+  "mediaType": "book",
+  "minified": false,
+  "collapseseries": true,
+  "include": ""
 }
 ```
 
-This endpoint returns a library's playlists for the authenticated user.
+This endpoint returns a library's items, optionally sorted and/or filtered.
 
 ### HTTP Request
 
-`GET https://abs.example.com/api/libraries/<ID>/playlists`
+`GET https://abs.example.com/api/libraries/<ID>/items`
 
 ### URL Parameters
 
@@ -1188,12 +648,18 @@ Parameter | Description
 --------- | -----------
 ID | The ID of the library.
 
-### Query Parameters
+### Optional Query Parameters
 
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-limit | Integer | `0` | Limit the number of returned results per page. If `0`, no limit will be applied.
-page | Integer | `0` | The page number (0 indexed) to request. If there is no limit applied, then page will have no effect and all results will be returned.
+Parameter | Type | Description
+--------- | ---- | -----------
+`limit` | Integer | Limit the number of returned results per page. If `0`, no limit will be applied.
+`page` | Integer | The page number (0 indexed) to request. If there is no limit applied, then page will have no effect and all results will be returned.
+`sort` | String | What to sort the results by. Specify the attribute to sort by using JavaScript object notation. For example, to sort by title use `sort=media.metadata.title`. When filtering for a series, sort can also be `sequence`.
+`desc` | Binary | Whether to reverse the sort order. `0` for false, `1` for true.
+`filter` | String | What to filter the results by. See [Filtering](#filtering).
+`minified` | Binary | Whether to request minified objects. `0` for false, `1` for true.
+`collapseseries` | Binary | Whether to collapse books in a series to a single entry. `0` for false, `1` for true.
+`include` | String | A comma separated list of what to include with the library items. The only current option is `rssfeed`.
 
 ### Response
 
@@ -1206,10 +672,17 @@ Status | Meaning | Description | Schema
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`results` | Array of [Playlist Expanded](#playlist-expanded) | The requested playlists.
+`results` | Array of [Library Item](#library-item) | The requested library items. If `minified` is `true`, it will be an array of [Library Item Minified](#library-item-minified). `collapseseries` will add a [Series Num Books](#series-num-books) as `collapsedSeries` to the library items, with only one library item per series. However, if there is only one series in the results, they will not be collapsed. When filtering by series, `media.metadata.series` will be replaced by the matching [Series Sequence](#series-sequence) object. If filtering by series, `collapseseries` is `true`, and there are multiple series, such as a subseries, a `seriesSequenceList` string attribute is added to `collapsedSeries` which represents the items in the subseries that are in the filtered series. `rssfeed` will add an [RSS Feed Minified](#rss-feed-minified) object or `null` as `rssFeed` to the library items, the item's RSS feed if it has one open.
 `total` | Integer | The total number of results.
 `limit` | Integer | The limit set in the request.
 `page` | Integer | The page set in request.
+`sortBy` | String | The sort set in the request. Will not exist if no sort was set.
+`sortDesc` | Boolean | Whether to reverse the sort order.
+`filterBy` | String | The filter set in the request, URL decoded. Will not exist if no filter was set.
+`mediaType` | String | The media type of the library. Will be `book` or `podcast`.
+`minified` | Boolean | Whether minified was set in the request.
+`collapseseries` | Boolean | Whether collapseseries was set in the request.
+`include` | String | The requested `include`.
 
 
 ## Get a Library's Personalized View
@@ -1694,10 +1167,10 @@ Attribute | Type | Description
     * Library items will have a `finishedAt` attribute, an Integer, the time (in ms since POSIX epoch) when the book or episode was finished.
 
 
-## Get a Library's Filter Data
+## Get a Library's Podcast Episode Downloads
 
 ```shell
-curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/filterdata" \
+curl "https://abs.example.com/api/libraries/lib_p9wkw2i85qy9oltijt/episode-downloads" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
@@ -1705,34 +1178,33 @@ curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/filterdata" \
 
 ```json
 {
-  "authors": [
-    {
-      "id": "aut_z3leimgybl7uf3y4ab",
-      "name": "Terry Goodkind"
-    }
-  ],
-  "genres": [
-    "Fantasy"
-  ],
-  "tags": [],
-  "series": [
-    {
-      "id": "ser_cabkj4jeu8be3rap4g",
-      "name": "Sword of Truth"
-    }
-  ],
-  "narrators": [
-    "Sam Tsoutsouvas"
-  ],
-  "languages": []
+  "currentDownload": {
+    "id": "epdl_pgv4d47j6dtqpk4r0v",
+    "episodeDisplayTitle": "2 - Glow Cloud",
+    "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/cb1dd91f-5d8d-42e9-ba22-14ff335d2cbb/2_Glow_Cloud.mp3",
+    "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+    "libraryId": "lib_p9wkw2i85qy9oltijt",
+    "isFinished": false,
+    "failed": false,
+    "startedAt": null,
+    "createdAt": 1668122813409,
+    "finishedAt": null,
+    "podcastTitle": "Welcome to Night Vale",
+    "podcastExplicit": false,
+    "season": "",
+    "episode": "",
+    "episodeType": "full",
+    "publishedAt": 1341144000000
+  },
+  "queue": []
 }
 ```
 
-This endpoint returns a library's filter data that can be used for displaying a filter list.
+This endpoint retrieves the podcast episodes downloads of the library.
 
 ### HTTP Request
 
-`GET https://abs.example.com/api/libraries/<ID>/filterdata`
+`GET http://abs.example.com/api/libraries/<ID>/episode-downloads`
 
 ### URL Parameters
 
@@ -1744,8 +1216,968 @@ ID | The ID of the library.
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
-200 | OK | Success | [Library Filter Data](#library-filter-data)
+200 | OK | Success | See below.
+404 | Not Found | No library with the given ID exists, or the user cannot access it. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`currentDownload` | [Podcast Episode Download](#podcast-episode-download) Object | The podcast episode currently being downloaded. Will only exist if an episode download is in progress.
+`queue` | Array of [Podcast Episode Download](#podcast-episode-download) | The podcast episodes in the queue to be downloaded.
+
+
+## Get a Library's Recent Episodes
+
+```shell
+curl "https://abs.example.com/api/libraries/lib_p9wkw2i85qy9oltijt/recent-episodes" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "episodes": [
+    {
+      "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+      "id": "ep_lh6ko39pumnrma3dhv",
+      "index": 1,
+      "season": "",
+      "episode": "",
+      "episodeType": "full",
+      "title": "1 - Pilot",
+      "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
+      "description": "<div><br>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.<br><br></div><div><br>Weather: \"These and More Than These\" by Joseph Fink<br><br></div><div><br>Music: Disparition, disparition.info<br><br></div><div><br>Logo: Rob Wilson, silastom.com<br><br></div><div><br>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.<br><br></div>",
+      "enclosure": {
+        "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
+        "type": "audio/mpeg",
+        "length": "20588611"
+      },
+      "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
+      "audioFile": {
+        "index": 1,
+        "ino": "22587",
+        "metadata": {
+          "filename": "1 - Pilot.mp3",
+          "ext": ".mp3",
+          "path": "/podcasts/Welcome to Night Vale/1 - Pilot.mp3",
+          "relPath": "1 - Pilot.mp3",
+          "size": 23653735,
+          "mtimeMs": 1667326682557,
+          "ctimeMs": 1667326682557,
+          "birthtimeMs": 1667326679508
+        },
+        "addedAt": 1667326682605,
+        "updatedAt": 1667327311570,
+        "trackNumFromMeta": null,
+        "discNumFromMeta": null,
+        "trackNumFromFilename": null,
+        "discNumFromFilename": null,
+        "manuallyVerified": false,
+        "invalid": false,
+        "exclude": false,
+        "error": null,
+        "format": "MP2/3 (MPEG audio layer 2/3)",
+        "duration": 1454.18449,
+        "bitRate": 128000,
+        "language": null,
+        "codec": "mp3",
+        "timeBase": "1/14112000",
+        "channels": 2,
+        "channelLayout": "stereo",
+        "chapters": [],
+        "embeddedCoverArt": "mjpeg",
+        "metaTags": {
+          "tagAlbum": "Welcome to Night Vale",
+          "tagArtist": "Night Vale Presents",
+          "tagGenre": "Podcast",
+          "tagTitle": "1 - Pilot",
+          "tagDate": "2012",
+          "tagEncoder": "Lavf58.45.100"
+        },
+        "mimeType": "audio/mpeg"
+      },
+      "audioTrack": {
+        "index": 1,
+        "startOffset": 0,
+        "duration": 1454.18449,
+        "title": "1 - Pilot.mp3",
+        "contentUrl": "/s/item/li_bufnnmp4y5o2gbbxfm/1 - Pilot.mp3",
+        "mimeType": "audio/mpeg",
+        "metadata": {
+          "filename": "1 - Pilot.mp3",
+          "ext": ".mp3",
+          "path": "/podcasts/Welcome to Night Vale/1 - Pilot.mp3",
+          "relPath": "1 - Pilot.mp3",
+          "size": 23653735,
+          "mtimeMs": 1667326682557,
+          "ctimeMs": 1667326682557,
+          "birthtimeMs": 1667326679508
+        }
+      },
+      "publishedAt": 1339761600000,
+      "addedAt": 1667326679503,
+      "updatedAt": 1667428186431,
+      "duration": 1454.18449,
+      "size": 23653735,
+      "podcast": {
+        "metadata": {
+          "title": "Welcome to Night Vale",
+          "titleIgnorePrefix": "Welcome to Night Vale",
+          "author": "Night Vale Presents",
+          "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+          "releaseDate": "2022-10-20T19:00:00Z",
+          "genres": [
+            "Science Fiction",
+            "Podcasts",
+            "Fiction"
+          ],
+          "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
+          "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
+          "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
+          "itunesId": 536258179,
+          "itunesArtistId": 718704794,
+          "explicit": false,
+          "language": null
+        },
+        "coverPath": "/podcasts/Welcome to Night Vale/cover.jpg",
+        "tags": [],
+        "numEpisodes": 1,
+        "autoDownloadEpisodes": false,
+        "autoDownloadSchedule": "0 0 * * 1",
+        "lastEpisodeCheck": 1667326662087,
+        "maxEpisodesToKeep": 0,
+        "maxNewEpisodesToDownload": 3,
+        "size": 23653735
+      }
+    }
+  ],
+  "total": 1,
+  "limit": 0,
+  "page": 0
+}
+```
+
+This endpoint returns a library's newest unfinished podcast episodes, sorted by episode publish time.
+
+### HTTP Request
+
+`GET https://abs.example.com/api/libraries/<ID>/recent-episodes`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library.
+
+### Optional Query Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+limit | Integer | Limit the number of returned results per page. If `0`, no limit will be applied.
+page | Integer | The page number (0 indexed) to request. If there is no limit applied, then page will have no effect and all results will be returned.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
 404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`episodes` | Array of [Podcast Episode Expanded](#podcast-episode-expanded) | The library's newest unfinished podcast episodes, sorted by episode publish time. The episodes have an additional `podcast` attribute, a [Podcast Minified](#podcast-minified), the podcast the episode belongs to.
+`total` | Integer | The total number of podcast episodes in the library.
+`limit` | Integer | The limit set in the request.
+`page` | Integer | The page set in request.
+
+
+## Get a Library's Series
+
+```shell
+curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/series?minified=1" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "results": [
+    {
+      "id": "ser_cabkj4jeu8be3rap4g",
+      "name": "Sword of Truth",
+      "nameIgnorePrefix": "Sword of Truth",
+      "nameIgnorePrefixSort": "Sword of Truth",
+      "type": "series",
+      "books": [
+        {
+          "id": "li_8gch9ve09orgn4fdz8",
+          "ino": "649641337522215266",
+          "libraryId": "main",
+          "folderId": "audiobooks",
+          "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
+          "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
+          "isFile": false,
+          "mtimeMs": 1650621074299,
+          "ctimeMs": 1650621074299,
+          "birthtimeMs": 0,
+          "addedAt": 1650621073750,
+          "updatedAt": 1650621110769,
+          "isMissing": false,
+          "isInvalid": false,
+          "mediaType": "book",
+          "media": {
+            "metadata": {
+              "title": "Wizards First Rule",
+              "titleIgnorePrefix": "Wizards First Rule",
+              "subtitle": null,
+              "authorName": "Terry Goodkind",
+              "narratorName": "Sam Tsoutsouvas",
+              "seriesName": "Sword of Truth",
+              "genres": [
+                "Fantasy"
+              ],
+              "publishedYear": "2008",
+              "publishedDate": null,
+              "publisher": "Brilliance Audio",
+              "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+              "isbn": null,
+              "asin": "B002V0QK4C",
+              "language": null,
+              "explicit": false
+            },
+            "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+            "tags": [],
+            "numTracks": 2,
+            "numAudioFiles": 2,
+            "numChapters": 2,
+            "numMissingParts": 0,
+            "numInvalidAudioFiles": 0,
+            "duration": 12000.946,
+            "size": 96010240,
+            "ebookFileFormat": null
+          },
+          "numFiles": 3,
+          "size": 96335771,
+          "sequence": "1"
+        }
+      ],
+      "addedAt": 1650621073750,
+      "totalDuration": 12000.946
+    }
+  ],
+  "total": 1,
+  "limit": 0,
+  "page": 0,
+  "sortBy": "media.metadata.title",
+  "sortDesc": false,
+  "filterBy": "authors.YXV0X3ozbGVpbWd5Ymw3dWYzeTRhYg==",
+  "mediaType": "book",
+  "minified": false,
+  "collapseseries": true,
+  "include": ""
+}
+```
+
+This endpoint returns a library's series.
+
+### HTTP Request
+
+`GET https://abs.example.com/api/libraries/<ID>/series`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library.
+
+### Optional Query Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`limit` | Integer | Limit the number of returned results per page. If `0`, no limit will be applied.
+`page` | Integer | The page number (0 indexed) to request. If there is no limit applied, then page will have no effect and all results will be returned.
+`sort` | String | What to sort the results by. By default, the results will be sorted by series name. Other sort options are: numBooks, totalDuration, and addedAt.
+`desc` | Binary | Whether to reverse the sort order. `0` for false, `1` for true.
+`filter` | String | What to filter the results by. See [Filtering](#filtering). The `issues` and `feed-open` filters are not available for this endpoint.
+`minified` | Binary | Whether to request minified objects. `0` for `false`, `1` for `true`.
+`include` | String | A comma separated list of what to include with the library items. The only current option is `rssfeed`.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`results` | Array of [Series Books](#series-books) | The requested series. If `minified` is `true`, the library items contained in the series will be [Library Item Minified](#library-item-minified). If `rssfeed` was requested, an [RSS Feed Minified](#rss-feed-minified) object or `null` as `rssFeed`, the series' RSS feed if it has one open, will be added to the series.
+`total` | Integer | The total number of results.
+`limit` | Integer | The limit set in the request.
+`page` | Integer | The page set in request.
+`sortBy` | String | The sort set in the request. Will not exist if no sort was set.
+`sortDesc` | Boolean | Whether to reverse the sort order.
+`filterBy` | String | The filter set in the request, URL decoded. Will not exist if no filter was set.
+`minified` | Boolean | Whether minified was set in the request.
+`include` | String | The requested `include`.
+
+
+## Get a Library's Stats
+
+```shell
+curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/stats" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "totalItems": 1,
+  "totalAuthors": 1,
+  "totalGenres": 1,
+  "totalDuration": 12000.946,
+  "longestItems": [
+    {
+      "id": "li_8gch9ve09orgn4fdz8",
+      "title": "Wizards First Rule",
+      "duration": 12000.946
+    }
+  ],
+  "numAudioTrack": 2,
+  "totalSize": 268990279,
+  "largestItems": [
+    {
+      "id": "li_8gch9ve09orgn4fdz8",
+      "title": "Wizards First Rule",
+      "size": 268990279
+    }
+  ],
+  "authorsWithCount": [
+    {
+      "id": "aut_z3leimgybl7uf3y4ab",
+      "name": "Terry Goodkind",
+      "count": 1
+    }
+  ],
+  "genresWithCount": [
+    {
+      "genre": "Fantasy",
+      "count": 1
+    }
+  ]
+}
+```
+
+This endpoint returns a library's stats.
+
+### HTTP Request
+
+`GET https://abs.example.com/api/libraries/<ID>/stats`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`totalItems` | Integer | The total amount of library items in the library.
+`totalAuthors` | Integer | The total amount of authors in the library.
+`totalGenres` | Integer | The total amount of genres in the library.
+`totalDuration` | Float | The total duration (in seconds) of all items in the library.
+`longestItems` | Array of [Library Item Duration Stats](#library-item-duration-stats) | The items with the longest durations in the library.
+`numAudioTrack` | Integer | The total number of audio tracks in the library.
+`totalSize` | Integer | The total size (in bytes) of all items in the library.
+`largestItems` | Array of [Library Item Size Stats](#library-item-size-stats) | The items with the largest size in the library.
+`authorsWithCount` | Array of [Author Stats](#author-stats) | The authors in the library.
+`genresWithCount` | Array of [Genre Stats](#genre-stats) | The genres in the library.
+
+#### Library Item Duration Stats
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the library item.
+`title` | String | The title of the library item.
+`duration` | Float | The duration (in seconds) of the library item.
+
+#### Library Item Size Stats
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the library item.
+`title` | String | The title of the library item.
+`size` | Integer | The size (in bytes) of the library item.
+
+#### Author Stats
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the author.
+`name` | String | The title of the author.
+`count` | Integer | The number of books by the author in the library.
+
+#### Genre Stats
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`genre` | String | The name of the genre.
+`count` | Integer | The number of items in the library with the genre.
+
+
+## Get a Library's User Playlists
+
+```shell
+curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/playlists" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "results": [
+    {
+      "id": "pl_qbwet64998s5ra6dcu",
+      "libraryId": "lib_c1u6t4p45c35rf0nzd",
+      "userId": "root",
+      "name": "Favorites",
+      "description": null,
+      "coverPath": null,
+      "items": [
+        {
+          "libraryItemId": "li_8gch9ve09orgn4fdz8",
+          "episodeId": null,
+          "libraryItem": {
+            "id": "li_8gch9ve09orgn4fdz8",
+            "ino": "649641337522215266",
+            "libraryId": "lib_c1u6t4p45c35rf0nzd",
+            "folderId": "fol_bev1zuxhb0j0s1wehr",
+            "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
+            "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
+            "isFile": false,
+            "mtimeMs": 1650621074299,
+            "ctimeMs": 1650621074299,
+            "birthtimeMs": 0,
+            "addedAt": 1650621073750,
+            "updatedAt": 1650621110769,
+            "lastScan": 1651830827825,
+            "scanVersion": "2.0.21",
+            "isMissing": false,
+            "isInvalid": false,
+            "mediaType": "book",
+            "media": {
+              "libraryItemId": "li_8gch9ve09orgn4fdz8",
+              "metadata": {
+                "title": "Wizards First Rule",
+                "titleIgnorePrefix": "Wizards First Rule",
+                "subtitle": null,
+                "authors": [
+                  {
+                    "id": "aut_z3leimgybl7uf3y4ab",
+                    "name": "Terry Goodkind"
+                  }
+                ],
+                "narrators": [
+                  "Sam Tsoutsouvas"
+                ],
+                "series": [
+                  {
+                    "id": "ser_cabkj4jeu8be3rap4g",
+                    "name": "Sword of Truth",
+                    "sequence": "1"
+                  }
+                ],
+                "genres": [
+                  "Fantasy"
+                ],
+                "publishedYear": "2008",
+                "publishedDate": null,
+                "publisher": "Brilliance Audio",
+                "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+                "isbn": null,
+                "asin": "B002V0QK4C",
+                "language": null,
+                "explicit": false,
+                "authorName": "Terry Goodkind",
+                "authorNameLF": "Goodkind, Terry",
+                "narratorName": "Sam Tsoutsouvas",
+                "seriesName": "Sword of Truth"
+              },
+              "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+              "tags": [
+                "Favorite"
+              ],
+              "audioFiles": [
+                {
+                  "index": 1,
+                  "ino": "649644248522215260",
+                  "metadata": {
+                    "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                    "ext": ".mp3",
+                    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                    "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                    "size": 48037888,
+                    "mtimeMs": 1632223180278,
+                    "ctimeMs": 1645978261001,
+                    "birthtimeMs": 0
+                  },
+                  "addedAt": 1650621074131,
+                  "updatedAt": 1651830828023,
+                  "trackNumFromMeta": 1,
+                  "discNumFromMeta": null,
+                  "trackNumFromFilename": 1,
+                  "discNumFromFilename": null,
+                  "manuallyVerified": false,
+                  "invalid": false,
+                  "exclude": false,
+                  "error": null,
+                  "format": "MP2/3 (MPEG audio layer 2/3)",
+                  "duration": 6004.6675,
+                  "bitRate": 64000,
+                  "language": null,
+                  "codec": "mp3",
+                  "timeBase": "1/14112000",
+                  "channels": 2,
+                  "channelLayout": "stereo",
+                  "chapters": [],
+                  "embeddedCoverArt": null,
+                  "metaTags": {
+                    "tagAlbum": "SOT Bk01",
+                    "tagArtist": "Terry Goodkind",
+                    "tagGenre": "Audiobook Fantasy",
+                    "tagTitle": "Wizards First Rule 01",
+                    "tagTrack": "01/20",
+                    "tagAlbumArtist": "Terry Goodkind",
+                    "tagComposer": "Terry Goodkind"
+                  },
+                  "mimeType": "audio/mpeg"
+                },
+                {
+                  "index": 2,
+                  "ino": "649644248522215261",
+                  "metadata": {
+                    "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                    "ext": ".mp3",
+                    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                    "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                    "size": 47972352,
+                    "mtimeMs": 1632223180281,
+                    "ctimeMs": 1645978261001,
+                    "birthtimeMs": 0
+                  },
+                  "addedAt": 1650621074130,
+                  "updatedAt": 1651830828023,
+                  "trackNumFromMeta": 2,
+                  "discNumFromMeta": null,
+                  "trackNumFromFilename": 1,
+                  "discNumFromFilename": null,
+                  "manuallyVerified": false,
+                  "invalid": false,
+                  "exclude": false,
+                  "error": null,
+                  "format": "MP2/3 (MPEG audio layer 2/3)",
+                  "duration": 5996.2785,
+                  "bitRate": 64000,
+                  "language": null,
+                  "codec": "mp3",
+                  "timeBase": "1/14112000",
+                  "channels": 2,
+                  "channelLayout": "stereo",
+                  "chapters": [],
+                  "embeddedCoverArt": null,
+                  "metaTags": {
+                    "tagAlbum": "SOT Bk01",
+                    "tagArtist": "Terry Goodkind",
+                    "tagGenre": "Audiobook Fantasy",
+                    "tagTitle": "Wizards First Rule 02",
+                    "tagTrack": "02/20",
+                    "tagAlbumArtist": "Terry Goodkind",
+                    "tagComposer": "Terry Goodkind"
+                  },
+                  "mimeType": "audio/mpeg"
+                }
+              ],
+              "chapters": [
+                {
+                  "id": 0,
+                  "start": 0,
+                  "end": 6004.6675,
+                  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
+                },
+                {
+                  "id": 1,
+                  "start": 6004.6675,
+                  "end": 12000.946,
+                  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
+                }
+              ],
+              "duration": 33854.905,
+              "size": 268824228,
+              "tracks": [
+                {
+                  "index": 1,
+                  "startOffset": 0,
+                  "duration": 6004.6675,
+                  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                  "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                  "mimeType": "audio/mpeg",
+                  "metadata": {
+                    "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                    "ext": ".mp3",
+                    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                    "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                    "size": 48037888,
+                    "mtimeMs": 1632223180278,
+                    "ctimeMs": 1645978261001,
+                    "birthtimeMs": 0
+                  }
+                },
+                {
+                  "index": 2,
+                  "startOffset": 6004.6675,
+                  "duration": 5996.2785,
+                  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                  "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                  "mimeType": "audio/mpeg",
+                  "metadata": {
+                    "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                    "ext": ".mp3",
+                    "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                    "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
+                    "size": 47972352,
+                    "mtimeMs": 1632223180281,
+                    "ctimeMs": 1645978261001,
+                    "birthtimeMs": 0
+                  }
+                }
+              ],
+              "missingParts": [],
+              "ebookFile": null
+            },
+            "libraryFiles": [
+              {
+                "ino": "649644248522215260",
+                "metadata": {
+                  "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                  "ext": ".mp3",
+                  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                  "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                  "size": 48037888,
+                  "mtimeMs": 1632223180278,
+                  "ctimeMs": 1645978261001,
+                  "birthtimeMs": 0
+                },
+                "addedAt": 1650621052494,
+                "updatedAt": 1650621052494,
+                "fileType": "audio"
+              },
+              {
+                "ino": "649644248522215261",
+                "metadata": {
+                  "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                  "ext": ".mp3",
+                  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                  "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                  "size": 47972352,
+                  "mtimeMs": 1632223180281,
+                  "ctimeMs": 1645978261001,
+                  "birthtimeMs": 0
+                },
+                "addedAt": 1650621052494,
+                "updatedAt": 1650621052494,
+                "fileType": "audio"
+              },
+              {
+                "ino": "649644248522215267",
+                "metadata": {
+                  "filename": "cover.jpg",
+                  "ext": ".jpg",
+                  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+                  "relPath": "cover.jpg",
+                  "size": 325531,
+                  "mtimeMs": 1638754803540,
+                  "ctimeMs": 1645978261003,
+                  "birthtimeMs": 0
+                },
+                "addedAt": 1650621052495,
+                "updatedAt": 1650621052495,
+                "fileType": "image"
+              }
+            ],
+            "size": 268990279
+          }
+        }
+      ],
+      "lastUpdate": 1669623431313,
+      "createdAt": 1669623431313
+    }
+  ],
+  "total": 1,
+  "limit": 0,
+  "page": 0
+}
+```
+
+This endpoint returns a library's playlists for the authenticated user.
+
+### HTTP Request
+
+`GET https://abs.example.com/api/libraries/<ID>/playlists`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library.
+
+### Query Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+limit | Integer | `0` | Limit the number of returned results per page. If `0`, no limit will be applied.
+page | Integer | `0` | The page number (0 indexed) to request. If there is no limit applied, then page will have no effect and all results will be returned.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`results` | Array of [Playlist Expanded](#playlist-expanded) | The requested playlists.
+`total` | Integer | The total number of results.
+`limit` | Integer | The limit set in the request.
+`page` | Integer | The page set in request.
+
+
+## Library Icons
+
+Available library icons are:
+
+* <span class="abs-icons icon-database"></span> `database`
+* <span class="abs-icons icon-audiobookshelf"></span> `audiobookshelf`
+* <span class="abs-icons icon-books-1"></span> `books-1`
+* <span class="abs-icons icon-books-2"></span> `books-2`
+* <span class="abs-icons icon-book-1"></span> `book-1`
+* <span class="abs-icons icon-microphone-1"></span> `microphone-1`
+* <span class="abs-icons icon-microphone-3"></span> `microphone-3`
+* <span class="abs-icons icon-radio"></span> `radio`
+* <span class="abs-icons icon-podcast"></span> `podcast`
+* <span class="abs-icons icon-rss"></span> `rss`
+* <span class="abs-icons icon-headphones"></span> `headphones`
+* <span class="abs-icons icon-music"></span> `music`
+* <span class="abs-icons icon-file-picture"></span> `file-picture`
+* <span class="abs-icons icon-rocket"></span> `rocket`
+* <span class="abs-icons icon-power"></span> `power`
+* <span class="abs-icons icon-star"></span> `star`
+* <span class="abs-icons icon-heart"></span> `heart`
+
+
+## Match All of a Library's Items
+
+```shell
+curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/matchall" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint matches all items in a library using quick match. Quick match populates empty book details and the cover with the first book result from the library's default metadata provider. Does not overwrite details unless the "Prefer matched metadata" server setting is enabled.
+
+### HTTP Request
+
+`GET https://abs.example.com/api/libraries/<ID>/matchall`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | An admin user is required to match library items.
+404 | Not Found | The user cannot access the library, or no library with the provided ID exists.
+
+
+## Remove a Library's Items With Issues
+
+```shell
+curl -X DELETE "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/issues" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint removes a library's items that have issues.
+
+### HTTP Request
+
+`DELETE https://abs.example.com/api/libraries/<ID>/issues`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+404 | Not Found | The user cannot access the library, or no library with the provided ID exists.
+
+
+## Reorder Library List
+
+```shell
+curl -X POST "https://abs.example.com/api/libraries/order" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+  -H "Content-Type: application/json"
+  -d '[{"id": "lib_5yvub9dqvctlcrza6h", "newOrder": 1}, {"id": "lib_c1u6t4p45c35rf0nzd", "newOrder": 2}]'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "libraries": [
+    {
+      "id": "lib_5yvub9dqvctlcrza6h",
+      "name": "Main",
+      "folders": [
+        {
+          "id": "audiobooks",
+          "fullPath": "/audiobooks",
+          "libraryId": "main"
+        }
+      ],
+      "displayOrder": 1,
+      "icon": "audiobookshelf",
+      "mediaType": "book",
+      "provider": "audible",
+      "settings": {
+        "coverAspectRatio": 1,
+        "disableWatcher": false,
+        "skipMatchingMediaWithAsin": false,
+        "skipMatchingMediaWithIsbn": false,
+        "autoScanCronExpression": null
+      },
+      "createdAt": 1633522963509,
+      "lastUpdate": 1646520916818
+    },
+    {
+      "id": "lib_c1u6t4p45c35rf0nzd",
+      "name": "Podcasts",
+      "folders": [
+        {
+          "id": "fol_bev1zuxhb0j0s1wehr",
+          "fullPath": "/podcasts",
+          "libraryId": "lib_c1u6t4p45c35rf0nzd",
+          "addedAt": 1650462940610
+        }
+      ],
+      "displayOrder": 2,
+      "icon": "database",
+      "mediaType": "podcast",
+      "provider": "itunes",
+      "settings": {
+        "coverAspectRatio": 1,
+        "disableWatcher": false,
+        "skipMatchingMediaWithAsin": false,
+        "skipMatchingMediaWithIsbn": false,
+        "autoScanCronExpression": null
+      },
+      "createdAt": 1650462940610,
+      "lastUpdate": 1650462940610
+    }
+  ]
+}
+```
+
+This endpoint will change the `displayOrder` of the libraries specified. It will return an array of all libraries.
+
+### HTTP Request
+
+`POST https://abs.example.com/api/libraries/order`
+
+### Required Parameters
+
+The POST body should be an array of objects like so:
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the library to set the `displayOrder` of.
+`newOrder` | Integer | The new `displayOrder` for the library.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+403 | Forbidden | An admin user is required to reorder libraries.
+500 | Internal Server Error | One or more of the IDs do not match any libraries.
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`libraries` | Array of [Library](#library) | All the libraries.
+
+## Scan a Library's Folders
+
+```shell
+curl -X POST "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/scan" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint starts a scan of a library's folders for new library items and changes to existing library items.
+
+### HTTP Request
+
+`POST https://abs.example.com/api/libraries/<ID>/scan`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library.
+
+### Optional Query Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+force | Binary | Whether to force a rescan for all of a library's items. `0` for false, `1` for true.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | An admin user is required to start a scan.
+404 | Not Found | The user cannot access the library, or no library with the provided ID exists.
 
 
 ## Search a Library
@@ -2086,516 +2518,83 @@ Attribute | Type | Description
 `matchText` | String or null | The text in the library item that the query matched to.
 
 
-## Get a Library's Stats
+## Update a Library
 
 ```shell
-curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/stats" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "totalItems": 1,
-  "totalAuthors": 1,
-  "totalGenres": 1,
-  "totalDuration": 12000.946,
-  "longestItems": [
-    {
-      "id": "li_8gch9ve09orgn4fdz8",
-      "title": "Wizards First Rule",
-      "duration": 12000.946
-    }
-  ],
-  "numAudioTrack": 2,
-  "totalSize": 268990279,
-  "largestItems": [
-    {
-      "id": "li_8gch9ve09orgn4fdz8",
-      "title": "Wizards First Rule",
-      "size": 268990279
-    }
-  ],
-  "authorsWithCount": [
-    {
-      "id": "aut_z3leimgybl7uf3y4ab",
-      "name": "Terry Goodkind",
-      "count": 1
-    }
-  ],
-  "genresWithCount": [
-    {
-      "genre": "Fantasy",
-      "count": 1
-    }
-  ]
-}
-```
-
-This endpoint returns a library's stats.
-
-### HTTP Request
-
-`GET https://abs.example.com/api/libraries/<ID>/stats`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`totalItems` | Integer | The total amount of library items in the library.
-`totalAuthors` | Integer | The total amount of authors in the library.
-`totalGenres` | Integer | The total amount of genres in the library.
-`totalDuration` | Float | The total duration (in seconds) of all items in the library.
-`longestItems` | Array of [Library Item Duration Stats](#library-item-duration-stats) | The items with the longest durations in the library.
-`numAudioTrack` | Integer | The total number of audio tracks in the library.
-`totalSize` | Integer | The total size (in bytes) of all items in the library.
-`largestItems` | Array of [Library Item Size Stats](#library-item-size-stats) | The items with the largest size in the library.
-`authorsWithCount` | Array of [Author Stats](#author-stats) | The authors in the library.
-`genresWithCount` | Array of [Genre Stats](#genre-stats) | The genres in the library.
-
-#### Library Item Duration Stats
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the library item.
-`title` | String | The title of the library item.
-`duration` | Float | The duration (in seconds) of the library item.
-
-#### Library Item Size Stats
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the library item.
-`title` | String | The title of the library item.
-`size` | Integer | The size (in bytes) of the library item.
-
-#### Author Stats
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the author.
-`name` | String | The title of the author.
-`count` | Integer | The number of books by the author in the library.
-
-#### Genre Stats
-
-Attribute | Type | Description
---------- | ---- | -----------
-`genre` | String | The name of the genre.
-`count` | Integer | The number of items in the library with the genre.
-
-
-## Get a Library's Authors
-
-```shell
-curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/authors" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "authors": [
-    {
-      "id": "aut_z3leimgybl7uf3y4ab",
-      "asin": null,
-      "name": "Terry Goodkind",
-      "description": null,
-      "imagePath": null,
-      "addedAt": 1650621073750,
-      "updatedAt": 1650621073750,
-      "numBooks": 1
-    }
-  ]
-}
-```
-
-This endpoint returns a library's authors.
-
-### HTTP Request
-
-`GET https://abs.example.com/api/libraries/<ID>/authors`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`authors` | Array of [Author Expanded](#author-expanded) | The requested authors.
-
-
-## Match All of a Library's Items
-
-```shell
-curl "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/matchall" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint matches all items in a library using quick match. Quick match populates empty book details and the cover with the first book result from the library's default metadata provider. Does not overwrite details unless the "Prefer matched metadata" server setting is enabled.
-
-### HTTP Request
-
-`GET https://abs.example.com/api/libraries/<ID>/matchall`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | An admin user is required to match library items.
-404 | Not Found | The user cannot access the library, or no library with the provided ID exists.
-
-
-## Scan a Library's Folders
-
-```shell
-curl -X POST "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd/scan" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint starts a scan of a library's folders for new library items and changes to existing library items.
-
-### HTTP Request
-
-`POST https://abs.example.com/api/libraries/<ID>/scan`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library.
-
-### Optional Query Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-force | Binary | Whether to force a rescan for all of a library's items. `0` for false, `1` for true.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | An admin user is required to start a scan.
-404 | Not Found | The user cannot access the library, or no library with the provided ID exists.
-
-
-## Get a Library's Recent Episodes
-
-```shell
-curl "https://abs.example.com/api/libraries/lib_p9wkw2i85qy9oltijt/recent-episodes" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "episodes": [
-    {
-      "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-      "id": "ep_lh6ko39pumnrma3dhv",
-      "index": 1,
-      "season": "",
-      "episode": "",
-      "episodeType": "full",
-      "title": "1 - Pilot",
-      "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
-      "description": "<div><br>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.<br><br></div><div><br>Weather: \"These and More Than These\" by Joseph Fink<br><br></div><div><br>Music: Disparition, disparition.info<br><br></div><div><br>Logo: Rob Wilson, silastom.com<br><br></div><div><br>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.<br><br></div>",
-      "enclosure": {
-        "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
-        "type": "audio/mpeg",
-        "length": "20588611"
-      },
-      "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
-      "audioFile": {
-        "index": 1,
-        "ino": "22587",
-        "metadata": {
-          "filename": "1 - Pilot.mp3",
-          "ext": ".mp3",
-          "path": "/podcasts/Welcome to Night Vale/1 - Pilot.mp3",
-          "relPath": "1 - Pilot.mp3",
-          "size": 23653735,
-          "mtimeMs": 1667326682557,
-          "ctimeMs": 1667326682557,
-          "birthtimeMs": 1667326679508
-        },
-        "addedAt": 1667326682605,
-        "updatedAt": 1667327311570,
-        "trackNumFromMeta": null,
-        "discNumFromMeta": null,
-        "trackNumFromFilename": null,
-        "discNumFromFilename": null,
-        "manuallyVerified": false,
-        "invalid": false,
-        "exclude": false,
-        "error": null,
-        "format": "MP2/3 (MPEG audio layer 2/3)",
-        "duration": 1454.18449,
-        "bitRate": 128000,
-        "language": null,
-        "codec": "mp3",
-        "timeBase": "1/14112000",
-        "channels": 2,
-        "channelLayout": "stereo",
-        "chapters": [],
-        "embeddedCoverArt": "mjpeg",
-        "metaTags": {
-          "tagAlbum": "Welcome to Night Vale",
-          "tagArtist": "Night Vale Presents",
-          "tagGenre": "Podcast",
-          "tagTitle": "1 - Pilot",
-          "tagDate": "2012",
-          "tagEncoder": "Lavf58.45.100"
-        },
-        "mimeType": "audio/mpeg"
-      },
-      "audioTrack": {
-        "index": 1,
-        "startOffset": 0,
-        "duration": 1454.18449,
-        "title": "1 - Pilot.mp3",
-        "contentUrl": "/s/item/li_bufnnmp4y5o2gbbxfm/1 - Pilot.mp3",
-        "mimeType": "audio/mpeg",
-        "metadata": {
-          "filename": "1 - Pilot.mp3",
-          "ext": ".mp3",
-          "path": "/podcasts/Welcome to Night Vale/1 - Pilot.mp3",
-          "relPath": "1 - Pilot.mp3",
-          "size": 23653735,
-          "mtimeMs": 1667326682557,
-          "ctimeMs": 1667326682557,
-          "birthtimeMs": 1667326679508
-        }
-      },
-      "publishedAt": 1339761600000,
-      "addedAt": 1667326679503,
-      "updatedAt": 1667428186431,
-      "duration": 1454.18449,
-      "size": 23653735,
-      "podcast": {
-        "metadata": {
-          "title": "Welcome to Night Vale",
-          "titleIgnorePrefix": "Welcome to Night Vale",
-          "author": "Night Vale Presents",
-          "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-          "releaseDate": "2022-10-20T19:00:00Z",
-          "genres": [
-            "Science Fiction",
-            "Podcasts",
-            "Fiction"
-          ],
-          "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
-          "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
-          "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
-          "itunesId": 536258179,
-          "itunesArtistId": 718704794,
-          "explicit": false,
-          "language": null
-        },
-        "coverPath": "/podcasts/Welcome to Night Vale/cover.jpg",
-        "tags": [],
-        "numEpisodes": 1,
-        "autoDownloadEpisodes": false,
-        "autoDownloadSchedule": "0 0 * * 1",
-        "lastEpisodeCheck": 1667326662087,
-        "maxEpisodesToKeep": 0,
-        "maxNewEpisodesToDownload": 3,
-        "size": 23653735
-      }
-    }
-  ],
-  "total": 1,
-  "limit": 0,
-  "page": 0
-}
-```
-
-This endpoint returns a library's newest unfinished podcast episodes, sorted by episode publish time.
-
-### HTTP Request
-
-`GET https://abs.example.com/api/libraries/<ID>/recent-episodes`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library.
-
-### Optional Query Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-limit | Integer | Limit the number of returned results per page. If `0`, no limit will be applied.
-page | Integer | The page number (0 indexed) to request. If there is no limit applied, then page will have no effect and all results will be returned.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`episodes` | Array of [Podcast Episode Expanded](#podcast-episode-expanded) | The library's newest unfinished podcast episodes, sorted by episode publish time. The episodes have an additional `podcast` attribute, a [Podcast Minified](#podcast-minified), the podcast the episode belongs to.
-`total` | Integer | The total number of podcast episodes in the library.
-`limit` | Integer | The limit set in the request.
-`page` | Integer | The page set in request.
-
-
-## Reorder Library List
-
-```shell
-curl -X POST "https://abs.example.com/api/libraries/order" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+curl -X PATCH "https://abs.example.com/api/libraries/lib_c1u6t4p45c35rf0nzd" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
   -H "Content-Type: application/json"
-  -d '[{"id": "lib_5yvub9dqvctlcrza6h", "newOrder": 1}, {"id": "lib_c1u6t4p45c35rf0nzd", "newOrder": 2}]'
+  -d '{"name": "Pods", "icon": "podcast"}'
 ```
 
 > The above command returns JSON structured like this:
 
 ```json
 {
-  "libraries": [
+  "id": "lib_c1u6t4p45c35rf0nzd",
+  "name": "Pods",
+  "folders": [
     {
-      "id": "lib_5yvub9dqvctlcrza6h",
-      "name": "Main",
-      "folders": [
-        {
-          "id": "audiobooks",
-          "fullPath": "/audiobooks",
-          "libraryId": "main"
-        }
-      ],
-      "displayOrder": 1,
-      "icon": "audiobookshelf",
-      "mediaType": "book",
-      "provider": "audible",
-      "settings": {
-        "coverAspectRatio": 1,
-        "disableWatcher": false,
-        "skipMatchingMediaWithAsin": false,
-        "skipMatchingMediaWithIsbn": false,
-        "autoScanCronExpression": null
-      },
-      "createdAt": 1633522963509,
-      "lastUpdate": 1646520916818
-    },
-    {
-      "id": "lib_c1u6t4p45c35rf0nzd",
-      "name": "Podcasts",
-      "folders": [
-        {
-          "id": "fol_bev1zuxhb0j0s1wehr",
-          "fullPath": "/podcasts",
-          "libraryId": "lib_c1u6t4p45c35rf0nzd",
-          "addedAt": 1650462940610
-        }
-      ],
-      "displayOrder": 2,
-      "icon": "database",
-      "mediaType": "podcast",
-      "provider": "itunes",
-      "settings": {
-        "coverAspectRatio": 1,
-        "disableWatcher": false,
-        "skipMatchingMediaWithAsin": false,
-        "skipMatchingMediaWithIsbn": false,
-        "autoScanCronExpression": null
-      },
-      "createdAt": 1650462940610,
-      "lastUpdate": 1650462940610
+      "id": "fol_bev1zuxhb0j0s1wehr",
+      "fullPath": "/podcasts",
+      "libraryId": "lib_c1u6t4p45c35rf0nzd",
+      "addedAt": 1650462940610
     }
-  ]
+  ],
+  "displayOrder": 4,
+  "icon": "podcast",
+  "mediaType": "podcast",
+  "provider": "itunes",
+  "settings": {
+    "coverAspectRatio": 1,
+    "disableWatcher": false,
+    "skipMatchingMediaWithAsin": false,
+    "skipMatchingMediaWithIsbn": false,
+    "autoScanCronExpression": null
+  },
+  "createdAt": 1650462940610,
+  "lastUpdate": 1655423464567
 }
 ```
 
-This endpoint will change the `displayOrder` of the libraries specified. It will return an array of all libraries.
+This endpoint updates a library.
 
 ### HTTP Request
 
-`POST https://abs.example.com/api/libraries/order`
+`PATCH https://abs.example.com/api/libraries/<ID>`
 
-### Required Parameters
+### URL Parameters
 
-The POST body should be an array of objects like so:
+Parameter | Description
+--------- | -----------
+ID | The ID of the library to update.
+
+### Parameters
 
 Parameter | Type | Description
 --------- | ---- | -----------
-`id` | String | The ID of the library to set the `displayOrder` of.
-`newOrder` | Integer | The new `displayOrder` for the library.
+`name` | String | The name of the library.
+`folders` | Array of [Folder](#folder) | See the notice below. Only specify the `fullPath` for new folders.
+`displayOrder` | Integer | Display position of the library in the list of libraries. Must be `>= 1`.
+`icon` | String | The icon of the library. See [Library Icons](#library-icons) for a list of possible icons.
+`provider` | String | Preferred metadata provider for the library. See [Metadata Providers](#metadata-providers) for a list of possible providers.
+`settings` | [Library Settings](#library-settings) Object | The settings for the library.
+
+#### Library Settings Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`coverAspectRatio` | Integer | Whether the library should use square book covers. Must be `0` (for false) or `1` (for true).
+`disableWatcher` | Boolean | Whether to disable the folder watcher for the library.
+`skipMatchingMediaWithAsin` | Boolean | Whether to skip matching books that already have an ASIN.
+`skipMatchingMediaWithIsbn` | Boolean | Whether to skip matching books that already have an ISBN.
+`autoScanCronExpression` | String or null | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to automatically scan the library folders. If `null`, automatic scanning will be disabled.
+
+<aside class="notice">When updating folders you must pass in the full array of folders. Any missing folders from the array will be removed. New folders must not have an <code>id</code> set because this will be set automatically.</aside>
 
 ### Response
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
-200 | OK | Success | See Below
-403 | Forbidden | An admin user is required to reorder libraries.
-500 | Internal Server Error | One or more of the IDs do not match any libraries.
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`libraries` | Array of [Library](#library) | All the libraries.
-
-## Library Icons
-
-Available library icons are:
-
-* <span class="abs-icons icon-database"></span> `database`
-* <span class="abs-icons icon-audiobookshelf"></span> `audiobookshelf`
-* <span class="abs-icons icon-books-1"></span> `books-1`
-* <span class="abs-icons icon-books-2"></span> `books-2`
-* <span class="abs-icons icon-book-1"></span> `book-1`
-* <span class="abs-icons icon-microphone-1"></span> `microphone-1`
-* <span class="abs-icons icon-microphone-3"></span> `microphone-3`
-* <span class="abs-icons icon-radio"></span> `radio`
-* <span class="abs-icons icon-podcast"></span> `podcast`
-* <span class="abs-icons icon-rss"></span> `rss`
-* <span class="abs-icons icon-headphones"></span> `headphones`
-* <span class="abs-icons icon-music"></span> `music`
-* <span class="abs-icons icon-file-picture"></span> `file-picture`
-* <span class="abs-icons icon-rocket"></span> `rocket`
-* <span class="abs-icons icon-power"></span> `power`
-* <span class="abs-icons icon-star"></span> `star`
-* <span class="abs-icons icon-heart"></span> `heart`
-
+200 | OK | Success | [Library](#library)
+404 | Not Found | The user cannot access the library, or no library with the provided ID exists. |

--- a/source/includes/_me.md
+++ b/source/includes/_me.md
@@ -1,11 +1,183 @@
 # Me
 
-All the "Me" endpoints are based off of the authenticated user. In these docs, "you" will refer to the authenticated user.
-
-## Get Your User
+## Batch Create/Update Media Progress
 
 ```shell
-curl "https://abs.example.com/api/me" \
+curl -X PATCH "https://abs.example.com/api/me/progress/batch/update" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '[{"libraryItemId": "li_bufnnmp4y5o2gbbxfm", "episodeId": "ep_lh6ko39pumnrma3dhv", "isFinished": true}]'
+```
+
+This endpoint batch creates/updates your media progress.
+
+### HTTP Request
+
+`PATCH http://abs.example.com/api/me/progress/batch/update`
+
+### Parameters
+
+Provide an array of objects with the following parameters:
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`libraryItemId` | String | **Required** | The ID of the library item the media progress is for.
+`episodeId` | String or null | `null` | The ID of the podcast episode the media progress is for.
+`duration` | Float | `0` | The total duration (in seconds) of the media.
+`progress` | Float | `0` or `1` | The percentage completion progress of the media. Will automatically be set to `1` if the media is finished.
+`currentTime` | Float | `0` | The current time (in seconds) of your progress.
+`isFinished` | Boolean | `false` | Whether the media is finished.
+`hideFromContinueListening` | Boolean | `false` | Whether the media will be hidden from the "Continue Listening" shelf.
+`finishedAt` | Integer or null | `null` or `Date.now()` | The time (in ms since POSIX epoch) when the user finished the media. The default will be `Date.now()` if `isFinished` is `true`.
+`startedAt` | Integer | `Date.now()` or `finishedAt` | The time (in ms since POSIX epoch) when the user started consuming the media. The default will be the value of `finishedAt` if `isFinished` is `true`.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+400 | Bad Request | The provided array must have a non-zero length.
+
+
+## Change Your Password
+
+```shell
+curl -X PATCH "https://abs.example.com/api/me/password" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"password": "12345", "newPassword": "54321"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "success": true
+}
+```
+
+This endpoint changes your password.
+
+### HTTP Request
+
+`PATCH http://abs.example.com/api/me/password`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`password` | String | Your current password.
+`newPassword` | String | Your new password.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+500 | Internal Server Error | Guest users cannot change their password. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`success` | Boolean | Will only exist and be `true` if the password was updated successfully.
+`error` | String | The error that occurred. Will only exist if there was an error updating your password.
+
+
+## Create a Bookmark
+
+```shell
+curl -X POST "https://abs.example.com/api/me/item/li_bufnnmp4y5o2gbbxfm/bookmark" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"time": 16, "title": "the good part"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "libraryItemId": "li_8gch9ve09orgn4fdz8",
+  "title": "the good part",
+  "time": 16,
+  "createdAt": 1668120083771
+}
+```
+
+This endpoint creates a bookmark for a book library item and returns the created bookmark.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/me/item/<ID>/bookmark`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library item to create a bookmark for.
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`time` | Integer | The time (in seconds) in the book to create the bookmark at.
+`title` | String | The title of the bookmark.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Audio Bookmark](#audio-bookmark)
+404 | Not Found | No library item with the provided ID exists. |
+
+
+## Create/Update Media Progress
+
+```shell
+curl -X PATCH "https://abs.example.com/api/me/progress/li_bufnnmp4y5o2gbbxfm/ep_lh6ko39pumnrma3dhv" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"isFinished": true}'
+```
+
+This endpoint creates/updates your media progress for a library item or podcast episode.
+
+### HTTP Request
+
+* `PATCH http://abs.example.com/api/me/progress/<LibraryItemID>`
+* `PATCH http://abs.example.com/api/me/progress/<LibraryItemID>/<EpisodeID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+LibraryItemID | The ID of the library item to create/update media progress for.
+EpisodeID | The ID of the podcast episode to create/update media progress for.
+
+### Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`duration` | Float | `0` | The total duration (in seconds) of the media.
+`progress` | Float | `0` or `1` | The percentage completion progress of the media. Will automatically be set to `1` if the media is finished.
+`currentTime` | Float | `0` | The current time (in seconds) of your progress.
+`isFinished` | Boolean | `false` | Whether the media is finished.
+`hideFromContinueListening` | Boolean | `false` | Whether the media will be hidden from the "Continue Listening" shelf.
+`finishedAt` | Integer or null | `null` or `Date.now()` | The time (in ms since POSIX epoch) when the user finished the media. The default will be `Date.now()` if `isFinished` is `true`.
+`startedAt` | Integer | `Date.now()` or `finishedAt` | The time (in ms since POSIX epoch) when the user started consuming the media. The default will be the value of `finishedAt` if `isFinished` is `true`.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+404 | Not Found | No library items or podcast episodes were found with the given IDs.
+
+
+## Get Library Items In Progress
+
+```shell
+curl "https://abs.example.com/api/me/items-in-progress?limit=1" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
@@ -13,42 +185,154 @@ curl "https://abs.example.com/api/me" \
 
 ```json
 {
-  "id": "root",
-  "username": "root",
-  "type": "root",
-  "token": "exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY",
-  "mediaProgress": [],
-  "seriesHideFromContinueListening": [],
-  "bookmarks": [],
-  "isActive": true,
-  "isLocked": false,
-  "lastSeen": 1667687240810,
-  "createdAt": 1666569607117,
-  "permissions": {
-    "download": true,
-    "update": true,
-    "delete": true,
-    "upload": true,
-    "accessAllLibraries": true,
-    "accessAllTags": true,
-    "accessExplicitContent": true
-  },
-  "librariesAccessible": [],
-  "itemTagsAccessible": []
+  "libraryItems": [
+    {
+      "id": "li_bufnnmp4y5o2gbbxfm",
+      "ino": "652",
+      "libraryId": "lib_p9wkw2i85qy9oltijt",
+      "folderId": "fol_crxarzs17jtw5k7ie9",
+      "path": "/podcasts/Welcome to Night Vale",
+      "relPath": "Welcome to Night Vale",
+      "isFile": false,
+      "mtimeMs": 1668124892694,
+      "ctimeMs": 1668124892694,
+      "birthtimeMs": 1667326662083,
+      "addedAt": 1667326662087,
+      "updatedAt": 1668157565937,
+      "isMissing": false,
+      "isInvalid": false,
+      "mediaType": "podcast",
+      "media": {
+        "metadata": {
+          "title": "Welcome to Night Vale",
+          "titleIgnorePrefix": "Welcome to Night Vale",
+          "author": "Night Vale Presents",
+          "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+          "releaseDate": "2022-10-20T19:00:00Z",
+          "genres": [
+            "Science Fiction",
+            "Podcasts",
+            "Fiction"
+          ],
+          "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
+          "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
+          "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
+          "itunesId": 536258179,
+          "itunesArtistId": 718704794,
+          "explicit": false,
+          "language": null
+        },
+        "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg",
+        "tags": [],
+        "numEpisodes": 1,
+        "autoDownloadEpisodes": false,
+        "autoDownloadSchedule": "0 0 * * 1",
+        "lastEpisodeCheck": 1667326662087,
+        "maxEpisodesToKeep": 0,
+        "maxNewEpisodesToDownload": 3,
+        "size": 23653735
+      },
+      "numFiles": 2,
+      "size": 23706728,
+      "recentEpisode": {
+        "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+        "id": "ep_lh6ko39pumnrma3dhv",
+        "index": 1,
+        "season": "",
+        "episode": "",
+        "episodeType": "full",
+        "title": "1 - Pilot",
+        "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
+        "description": "<div><br>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.<br><br></div><div><br>Weather: \"These and More Than These\" by Joseph Fink<br><br></div><div><br>Music: Disparition, disparition.info<br><br></div><div><br>Logo: Rob Wilson, silastom.com<br><br></div><div><br>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.<br><br></div>",
+        "enclosure": {
+          "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
+          "type": "audio/mpeg",
+          "length": "20588611"
+        },
+        "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
+        "audioFile": {
+          "index": 1,
+          "ino": "22587",
+          "metadata": {
+            "filename": "1 - Pilot.mp3",
+            "ext": ".mp3",
+            "path": "/podcasts/Welcome to Night Vale/1 - Pilot.mp3",
+            "relPath": "1 - Pilot.mp3",
+            "size": 23653735,
+            "mtimeMs": 1667326682557,
+            "ctimeMs": 1667326682557,
+            "birthtimeMs": 1667326679508
+          },
+          "addedAt": 1667326682605,
+          "updatedAt": 1668234380150,
+          "trackNumFromMeta": null,
+          "discNumFromMeta": null,
+          "trackNumFromFilename": null,
+          "discNumFromFilename": null,
+          "manuallyVerified": false,
+          "invalid": false,
+          "exclude": false,
+          "error": null,
+          "format": "MP2/3 (MPEG audio layer 2/3)",
+          "duration": 1454.18449,
+          "bitRate": 128000,
+          "language": null,
+          "codec": "mp3",
+          "timeBase": "1/14112000",
+          "channels": 2,
+          "channelLayout": "stereo",
+          "chapters": [],
+          "embeddedCoverArt": "mjpeg",
+          "metaTags": {
+            "tagAlbum": "Welcome to Night Vale",
+            "tagArtist": "Night Vale Presents",
+            "tagGenre": "Podcast",
+            "tagTitle": "1 - Pilot",
+            "tagDate": "2012",
+            "tagEncoder": "Lavf58.45.100"
+          },
+          "mimeType": "audio/mpeg"
+        },
+        "publishedAt": 1339761600000,
+        "addedAt": 1667326679503,
+        "updatedAt": 1667428186431
+      },
+      "progressLastUpdate": 1668434165531
+    }
+  ]
 }
 ```
 
-This endpoint retrieves your user.
+This endpoint retrieves library items that are in progress (started, not finished).
 
 ### HTTP Request
 
-`GET http://abs.example.com/api/me`
+`GET http://abs.example.com/api/me/items-in-progress`
+
+### Optional Query Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`limit` | Integer | `25` | A limit for how many library items to return.
 
 ### Response
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
-200 | OK | Success | [User](#user)
+200 | OK | Success | See below.
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`libraryItems` | Array of [Library Item Minified](#library-item-minified) | The in progress library items. They have extra attributes which are described below.
+
+#### Extra Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`recentEpisode` | [Podcast Episode](#podcast-episode) Object | If the library item is for a podcast, the media progress's corresponding podcast episode. Will not exist for book library items.
+`progressLastUpdate` | Integer | The time (in ms since POSIX epoch) when the corresponding media progress was last updated.
 
 
 ## Get Your Listening Sessions
@@ -305,10 +589,10 @@ The keys of this object are each day (in the format YYYY-MM-DD) when you listene
 The keys of this object are each day of the week. The values are the total time (in seconds, Integer) you listened to library items on that day of the week.
 
 
-## Remove an Item From Continue Listening
+## Get Your User
 
 ```shell
-curl "https://abs.example.com/api/me/progress/li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv/remove-from-continue-listening" \
+curl "https://abs.example.com/api/me" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
@@ -320,21 +604,7 @@ curl "https://abs.example.com/api/me/progress/li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pu
   "username": "root",
   "type": "root",
   "token": "exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY",
-  "mediaProgress": [
-    {
-      "id": "li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv",
-      "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-      "episodeId": "ep_lh6ko39pumnrma3dhv",
-      "duration": 1454.18449,
-      "progress": 0.42057298864465265,
-      "currentTime": 611.590717,
-      "isFinished": false,
-      "hideFromContinueListening": true,
-      "lastUpdate": 1668330152157,
-      "startedAt": 1668120083771,
-      "finishedAt": null
-    }
-  ],
+  "mediaProgress": [],
   "seriesHideFromContinueListening": [],
   "bookmarks": [],
   "isActive": true,
@@ -355,17 +625,11 @@ curl "https://abs.example.com/api/me/progress/li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pu
 }
 ```
 
-This endpoint removes a library item, that has media progress associated with your user, from your "Continue Listening" shelf. Your user is returned.
+This endpoint retrieves your user.
 
 ### HTTP Request
 
-`GET http://abs.example.com/api/me/progress/<ID>/remove-from-continue-listening`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the **media progress** that refers to the library item to remove.
+`GET http://abs.example.com/api/me`
 
 ### Response
 
@@ -421,209 +685,6 @@ Status | Meaning | Description | Schema
 404 | Not Found | No media progress was found that matches the given IDs. |
 
 
-## Batch Create/Update Media Progress
-
-```shell
-curl -X PATCH "https://abs.example.com/api/me/progress/batch/update" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '[{"libraryItemId": "li_bufnnmp4y5o2gbbxfm", "episodeId": "ep_lh6ko39pumnrma3dhv", "isFinished": true}]'
-```
-
-This endpoint batch creates/updates your media progress.
-
-### HTTP Request
-
-`PATCH http://abs.example.com/api/me/progress/batch/update`
-
-### Parameters
-
-Provide an array of objects with the following parameters:
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`libraryItemId` | String | **Required** | The ID of the library item the media progress is for.
-`episodeId` | String or null | `null` | The ID of the podcast episode the media progress is for.
-`duration` | Float | `0` | The total duration (in seconds) of the media.
-`progress` | Float | `0` or `1` | The percentage completion progress of the media. Will automatically be set to `1` if the media is finished.
-`currentTime` | Float | `0` | The current time (in seconds) of your progress.
-`isFinished` | Boolean | `false` | Whether the media is finished.
-`hideFromContinueListening` | Boolean | `false` | Whether the media will be hidden from the "Continue Listening" shelf.
-`finishedAt` | Integer or null | `null` or `Date.now()` | The time (in ms since POSIX epoch) when the user finished the media. The default will be `Date.now()` if `isFinished` is `true`.
-`startedAt` | Integer | `Date.now()` or `finishedAt` | The time (in ms since POSIX epoch) when the user started consuming the media. The default will be the value of `finishedAt` if `isFinished` is `true`.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-400 | Bad Request | The provided array must have a non-zero length.
-
-
-## Create/Update Media Progress
-
-```shell
-curl -X PATCH "https://abs.example.com/api/me/progress/li_bufnnmp4y5o2gbbxfm/ep_lh6ko39pumnrma3dhv" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"isFinished": true}'
-```
-
-This endpoint creates/updates your media progress for a library item or podcast episode.
-
-### HTTP Request
-
-* `PATCH http://abs.example.com/api/me/progress/<LibraryItemID>`
-* `PATCH http://abs.example.com/api/me/progress/<LibraryItemID>/<EpisodeID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-LibraryItemID | The ID of the library item to create/update media progress for.
-EpisodeID | The ID of the podcast episode to create/update media progress for.
-
-### Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`duration` | Float | `0` | The total duration (in seconds) of the media.
-`progress` | Float | `0` or `1` | The percentage completion progress of the media. Will automatically be set to `1` if the media is finished.
-`currentTime` | Float | `0` | The current time (in seconds) of your progress.
-`isFinished` | Boolean | `false` | Whether the media is finished.
-`hideFromContinueListening` | Boolean | `false` | Whether the media will be hidden from the "Continue Listening" shelf.
-`finishedAt` | Integer or null | `null` or `Date.now()` | The time (in ms since POSIX epoch) when the user finished the media. The default will be `Date.now()` if `isFinished` is `true`.
-`startedAt` | Integer | `Date.now()` or `finishedAt` | The time (in ms since POSIX epoch) when the user started consuming the media. The default will be the value of `finishedAt` if `isFinished` is `true`.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-404 | Not Found | No library items or podcast episodes were found with the given IDs.
-
-
-## Remove a Media Progress
-
-```shell
-curl -X DELETE "https://abs.example.com/api/me/progress/li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint removes a media progress entry from your user.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/me/progress/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the media progress to remove.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-
-
-## Create a Bookmark
-
-```shell
-curl -X POST "https://abs.example.com/api/me/item/li_bufnnmp4y5o2gbbxfm/bookmark" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"time": 16, "title": "the good part"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "libraryItemId": "li_8gch9ve09orgn4fdz8",
-  "title": "the good part",
-  "time": 16,
-  "createdAt": 1668120083771
-}
-```
-
-This endpoint creates a bookmark for a book library item and returns the created bookmark.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/me/item/<ID>/bookmark`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library item to create a bookmark for.
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`time` | Integer | The time (in seconds) in the book to create the bookmark at.
-`title` | String | The title of the bookmark.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Audio Bookmark](#audio-bookmark)
-404 | Not Found | No library item with the provided ID exists. |
-
-
-## Update a Bookmark 
-
-```shell
-curl -X PATCH "https://abs.example.com/api/me/item/li_bufnnmp4y5o2gbbxfm/bookmark" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"time": 16, "title": "the better part"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "libraryItemId": "li_8gch9ve09orgn4fdz8",
-  "title": "the better part",
-  "time": 16,
-  "createdAt": 1668120083771
-}
-```
-
-This endpoint updates a bookmark and returns it.
-
-### HTTP Request
-
-`PATCH http://abs.example.com/api/me/item/<ID>/bookmark`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the library item to update a bookmark for.
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`time` | Integer | The time (in seconds) of the bookmark.
-`title` | String | The title of the bookmark.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Audio Bookmark](#audio-bookmark)
-404 | Not Found | No library item with the provided ID exists or no bookmark at the given `time` exists. |
-500 | Internal Server Error | Could not find the bookmark. |
-
-
 ## Remove a Bookmark
 
 ```shell
@@ -653,273 +714,30 @@ Status | Meaning | Description
 500 | Internal Server Error | The Time URL parameter must be a number.
 
 
-## Change Your Password
+## Remove a Media Progress
 
 ```shell
-curl -X PATCH "https://abs.example.com/api/me/password" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"password": "12345", "newPassword": "54321"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "success": true
-}
-```
-
-This endpoint changes your password.
-
-### HTTP Request
-
-`PATCH http://abs.example.com/api/me/password`
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`password` | String | Your current password.
-`newPassword` | String | Your new password.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-500 | Internal Server Error | Guest users cannot change their password. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`success` | Boolean | Will only exist and be `true` if the password was updated successfully.
-`error` | String | The error that occurred. Will only exist if there was an error updating your password.
-
-
-## Sync Local Media Progress
-
-```shell
-curl -X POST "https://abs.example.com/api/me/sync-local-progress" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"localMediaProgress": [{ "id": "local_li_bufnnmp4y5o2gbbxfm-local_ep_lh6ko39pumnrma3dhv", "libraryItemId": "li_bufnnmp4y5o2gbbxfm", "episodeId": "ep_lh6ko39pumnrma3dhv", "duration": 1454.18449, "progress": 0.011193983371394644, "currentTime": 16.278117, "isFinished": false, "hideFromContinueListening": false, "lastUpdate": 1668120246620, "startedAt": 1668120083771, "finishedAt": null}]}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "numServerProgressUpdates": 1,
-  "localProgressUpdates": [],
-  "serverProgressUpdates": {
-    "id": "li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv",
-    "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-    "episodeId": "ep_lh6ko39pumnrma3dhv",
-    "duration": 1454.18449,
-    "progress": 0.011193983371394644,
-    "currentTime": 16.278117,
-    "isFinished": false,
-    "hideFromContinueListening": false,
-    "lastUpdate": 1668120246620,
-    "startedAt": 1668120083771,
-    "finishedAt": null
-  },
-}
-```
-
-<aside class="warning">
-This endpoint will soon be <strong>deprecated</strong>.
-</aside>
-
-This endpoint syncs a mobile client's local media progress with the server. For any local media progress with a greater `lastUpdate` time than the `lastUpdate` time of the matching media progress on the server, the server's media progress is updated. If the server's `lastUpdate` time is greater, than the local media progress will be returned with the updated information.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/me/sync-local-progress`
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`localMediaProgress` | Array of [Media Progress](#media-progress) | The client's local media progress.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-500 | Internal Server Error | The `localMediaProgress` parameter is required. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`numServerProgressUpdates` | Integer | The number of media progress items that were updated on the server.
-`localProgressUpdates` | Array of [Media Progress](#media-progress) | Local media progress items with updated information from the server (server more recent).
-`serverProgressUpdates` | Array of [Media Progress](#media-progress) | Media progress items that were updated on the server (local more recent).
-
-
-## Get Library Items In Progress
-
-```shell
-curl "https://abs.example.com/api/me/items-in-progress?limit=1" \
+curl -X DELETE "https://abs.example.com/api/me/progress/li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
-> The above command returns JSON structured like this:
-
-```json
-{
-  "libraryItems": [
-    {
-      "id": "li_bufnnmp4y5o2gbbxfm",
-      "ino": "652",
-      "libraryId": "lib_p9wkw2i85qy9oltijt",
-      "folderId": "fol_crxarzs17jtw5k7ie9",
-      "path": "/podcasts/Welcome to Night Vale",
-      "relPath": "Welcome to Night Vale",
-      "isFile": false,
-      "mtimeMs": 1668124892694,
-      "ctimeMs": 1668124892694,
-      "birthtimeMs": 1667326662083,
-      "addedAt": 1667326662087,
-      "updatedAt": 1668157565937,
-      "isMissing": false,
-      "isInvalid": false,
-      "mediaType": "podcast",
-      "media": {
-        "metadata": {
-          "title": "Welcome to Night Vale",
-          "titleIgnorePrefix": "Welcome to Night Vale",
-          "author": "Night Vale Presents",
-          "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-          "releaseDate": "2022-10-20T19:00:00Z",
-          "genres": [
-            "Science Fiction",
-            "Podcasts",
-            "Fiction"
-          ],
-          "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
-          "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
-          "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
-          "itunesId": 536258179,
-          "itunesArtistId": 718704794,
-          "explicit": false,
-          "language": null
-        },
-        "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg",
-        "tags": [],
-        "numEpisodes": 1,
-        "autoDownloadEpisodes": false,
-        "autoDownloadSchedule": "0 0 * * 1",
-        "lastEpisodeCheck": 1667326662087,
-        "maxEpisodesToKeep": 0,
-        "maxNewEpisodesToDownload": 3,
-        "size": 23653735
-      },
-      "numFiles": 2,
-      "size": 23706728,
-      "recentEpisode": {
-        "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-        "id": "ep_lh6ko39pumnrma3dhv",
-        "index": 1,
-        "season": "",
-        "episode": "",
-        "episodeType": "full",
-        "title": "1 - Pilot",
-        "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
-        "description": "<div><br>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.<br><br></div><div><br>Weather: \"These and More Than These\" by Joseph Fink<br><br></div><div><br>Music: Disparition, disparition.info<br><br></div><div><br>Logo: Rob Wilson, silastom.com<br><br></div><div><br>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.<br><br></div>",
-        "enclosure": {
-          "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
-          "type": "audio/mpeg",
-          "length": "20588611"
-        },
-        "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
-        "audioFile": {
-          "index": 1,
-          "ino": "22587",
-          "metadata": {
-            "filename": "1 - Pilot.mp3",
-            "ext": ".mp3",
-            "path": "/podcasts/Welcome to Night Vale/1 - Pilot.mp3",
-            "relPath": "1 - Pilot.mp3",
-            "size": 23653735,
-            "mtimeMs": 1667326682557,
-            "ctimeMs": 1667326682557,
-            "birthtimeMs": 1667326679508
-          },
-          "addedAt": 1667326682605,
-          "updatedAt": 1668234380150,
-          "trackNumFromMeta": null,
-          "discNumFromMeta": null,
-          "trackNumFromFilename": null,
-          "discNumFromFilename": null,
-          "manuallyVerified": false,
-          "invalid": false,
-          "exclude": false,
-          "error": null,
-          "format": "MP2/3 (MPEG audio layer 2/3)",
-          "duration": 1454.18449,
-          "bitRate": 128000,
-          "language": null,
-          "codec": "mp3",
-          "timeBase": "1/14112000",
-          "channels": 2,
-          "channelLayout": "stereo",
-          "chapters": [],
-          "embeddedCoverArt": "mjpeg",
-          "metaTags": {
-            "tagAlbum": "Welcome to Night Vale",
-            "tagArtist": "Night Vale Presents",
-            "tagGenre": "Podcast",
-            "tagTitle": "1 - Pilot",
-            "tagDate": "2012",
-            "tagEncoder": "Lavf58.45.100"
-          },
-          "mimeType": "audio/mpeg"
-        },
-        "publishedAt": 1339761600000,
-        "addedAt": 1667326679503,
-        "updatedAt": 1667428186431
-      },
-      "progressLastUpdate": 1668434165531
-    }
-  ]
-}
-```
-
-This endpoint retrieves library items that are in progress (started, not finished).
+This endpoint removes a media progress entry from your user.
 
 ### HTTP Request
 
-`GET http://abs.example.com/api/me/items-in-progress`
+`DELETE http://abs.example.com/api/me/progress/<ID>`
 
-### Optional Query Parameters
+### URL Parameters
 
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`limit` | Integer | `25` | A limit for how many library items to return.
+Parameter | Description
+--------- | -----------
+ID | The ID of the media progress to remove.
 
 ### Response
 
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`libraryItems` | Array of [Library Item Minified](#library-item-minified) | The in progress library items. They have extra attributes which are described below.
-
-#### Extra Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`recentEpisode` | [Podcast Episode](#podcast-episode) Object | If the library item is for a podcast, the media progress's corresponding podcast episode. Will not exist for book library items.
-`progressLastUpdate` | Integer | The time (in ms since POSIX epoch) when the corresponding media progress was last updated.
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
 
 
 ## Remove a Series From Continue Listening
@@ -992,3 +810,182 @@ Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
 200 | OK | Success | [User](#user)
 404 | Not Found | No series matching the provided ID was found. |
+
+## Remove an Item From Continue Listening
+
+```shell
+curl "https://abs.example.com/api/me/progress/li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv/remove-from-continue-listening" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "root",
+  "username": "root",
+  "type": "root",
+  "token": "exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY",
+  "mediaProgress": [
+    {
+      "id": "li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv",
+      "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+      "episodeId": "ep_lh6ko39pumnrma3dhv",
+      "duration": 1454.18449,
+      "progress": 0.42057298864465265,
+      "currentTime": 611.590717,
+      "isFinished": false,
+      "hideFromContinueListening": true,
+      "lastUpdate": 1668330152157,
+      "startedAt": 1668120083771,
+      "finishedAt": null
+    }
+  ],
+  "seriesHideFromContinueListening": [],
+  "bookmarks": [],
+  "isActive": true,
+  "isLocked": false,
+  "lastSeen": 1667687240810,
+  "createdAt": 1666569607117,
+  "permissions": {
+    "download": true,
+    "update": true,
+    "delete": true,
+    "upload": true,
+    "accessAllLibraries": true,
+    "accessAllTags": true,
+    "accessExplicitContent": true
+  },
+  "librariesAccessible": [],
+  "itemTagsAccessible": []
+}
+```
+
+This endpoint removes a library item, that has media progress associated with your user, from your "Continue Listening" shelf. Your user is returned.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/me/progress/<ID>/remove-from-continue-listening`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the **media progress** that refers to the library item to remove.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [User](#user)
+
+
+## Sync Local Media Progress
+
+```shell
+curl -X POST "https://abs.example.com/api/me/sync-local-progress" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"localMediaProgress": [{ "id": "local_li_bufnnmp4y5o2gbbxfm-local_ep_lh6ko39pumnrma3dhv", "libraryItemId": "li_bufnnmp4y5o2gbbxfm", "episodeId": "ep_lh6ko39pumnrma3dhv", "duration": 1454.18449, "progress": 0.011193983371394644, "currentTime": 16.278117, "isFinished": false, "hideFromContinueListening": false, "lastUpdate": 1668120246620, "startedAt": 1668120083771, "finishedAt": null}]}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "numServerProgressUpdates": 1,
+  "localProgressUpdates": [],
+  "serverProgressUpdates": {
+    "id": "li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv",
+    "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+    "episodeId": "ep_lh6ko39pumnrma3dhv",
+    "duration": 1454.18449,
+    "progress": 0.011193983371394644,
+    "currentTime": 16.278117,
+    "isFinished": false,
+    "hideFromContinueListening": false,
+    "lastUpdate": 1668120246620,
+    "startedAt": 1668120083771,
+    "finishedAt": null
+  },
+}
+```
+
+<aside class="warning">
+This endpoint will soon be <strong>deprecated</strong>.
+</aside>
+
+This endpoint syncs a mobile client's local media progress with the server. For any local media progress with a greater `lastUpdate` time than the `lastUpdate` time of the matching media progress on the server, the server's media progress is updated. If the server's `lastUpdate` time is greater, than the local media progress will be returned with the updated information.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/me/sync-local-progress`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`localMediaProgress` | Array of [Media Progress](#media-progress) | The client's local media progress.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+500 | Internal Server Error | The `localMediaProgress` parameter is required. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`numServerProgressUpdates` | Integer | The number of media progress items that were updated on the server.
+`localProgressUpdates` | Array of [Media Progress](#media-progress) | Local media progress items with updated information from the server (server more recent).
+`serverProgressUpdates` | Array of [Media Progress](#media-progress) | Media progress items that were updated on the server (local more recent).
+
+
+## Update a Bookmark 
+
+```shell
+curl -X PATCH "https://abs.example.com/api/me/item/li_bufnnmp4y5o2gbbxfm/bookmark" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"time": 16, "title": "the better part"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "libraryItemId": "li_8gch9ve09orgn4fdz8",
+  "title": "the better part",
+  "time": 16,
+  "createdAt": 1668120083771
+}
+```
+
+This endpoint updates a bookmark and returns it.
+
+### HTTP Request
+
+`PATCH http://abs.example.com/api/me/item/<ID>/bookmark`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the library item to update a bookmark for.
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`time` | Integer | The time (in seconds) of the bookmark.
+`title` | String | The title of the bookmark.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Audio Bookmark](#audio-bookmark)
+404 | Not Found | No library item with the provided ID exists or no bookmark at the given `time` exists. |
+500 | Internal Server Error | Could not find the bookmark. |

--- a/source/includes/_misc.md
+++ b/source/includes/_misc.md
@@ -1,161 +1,159 @@
 # Misc
 
-## Upload Files
+## Delete a Genre
 
 ```shell
-curl -X POST "https://abs.example.com/api/upload" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -F title="Wizard's First Rule" \
-  -F author="Terry Goodkind" \
-  -F series="Sword of Truth" \
-  -F library="lib_c1u6t4p45c35rf0nzd" \
-  -F folder="fol_bev1zuxhb0j0s1wehr" \
-  -F 0=@"Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3" \
-  -F 1=@"Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3" \
-  -F 2=@cover.jpg
-```
-
-This endpoint uploads library item files to the server.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/upload`
-
-### Form Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`title` | String | The library item's title.
-`author` | String | Optionally, the library item's author.
-`series` | String | Optionally, the library item's series.
-`library` | String | The ID of the library to put the item in.
-`folder` | String | The ID of the folder to put the item in.
-
-The files will be put in a directory at `<folderDir>/<author>/<series>/<title>`.
-
-The form keys for the files can be anything as they are ignored.
-
-The following file types are supported:
-
-* `.png`
-* `.jpg`
-* `.jpeg`
-* `.webp`
-* `.m4b`
-* `.mp3`
-* `.m4a`
-* `.flac`
-* `.opus`
-* `.ogg`
-* `.oga`
-* `.mp4`
-* `.aac`
-* `.wma`
-* `.aiff`
-* `.wav`
-* `.webm`
-* `.webma`
-* `.epub`
-* `.pdf`
-* `.mobi`
-* `.azw3`
-* `.cbr`
-* `.cbz`
-* `.nfo`
-* `.txt`
-* `.opf`
-* `.abs`
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-400 | Bad Request | No files were provided.
-403 | Forbidden | A user with upload permissions is required.
-404 | Not Found | No library with the given ID exists, or no folder with the given ID exists in the library.
-500 | Internal Server Error | No files were provided, or the upload directory already exists.
-
-
-## Update Server Settings
-
-```shell
-curl -X PATCH "https://abs.example.com/api/settings" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"scannerFindCovers": false}'
+curl -X DELETE "https://abs.example.com/api/genres/TWFnaWM%3D" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
 > The above command returns JSON structured like this:
 
 ```json
 {
-  "success": true,
-  "serverSettings": {
-    "id": "server-settings",
-    "scannerFindCovers": false,
-    "scannerCoverProvider": "google",
-    "scannerParseSubtitle": false,
-    "scannerPreferAudioMetadata": false,
-    "scannerPreferOpfMetadata": false,
-    "scannerPreferMatchedMetadata": false,
-    "scannerDisableWatcher": true,
-    "scannerPreferOverdriveMediaMarker": false,
-    "scannerUseSingleThreadedProber": true,
-    "scannerMaxThreads": 0,
-    "scannerUseTone": false,
-    "storeCoverWithItem": false,
-    "storeMetadataWithItem": false,
-    "rateLimitLoginRequests": 10,
-    "rateLimitLoginWindow": 600000,
-    "backupSchedule": "30 1 * * *",
-    "backupsToKeep": 2,
-    "maxBackupSize": 1,
-    "backupMetadataCovers": true,
-    "loggerDailyLogsToKeep": 7,
-    "loggerScannerLogsToKeep": 2,
-    "homeBookshelfView": 1,
-    "bookshelfView": 1,
-    "sortingIgnorePrefix": false,
-    "sortingPrefixes": [
-      "the",
-      "a"
-    ],
-    "chromecastEnabled": false,
-    "enableEReader": false,
-    "dateFormat": "MM/dd/yyyy",
-    "timeFormat": "HH:mm",
-    "language": "en-us",
-    "logLevel": 2,
-    "version": "2.2.5"
-  }
+  "numItemsUpdated": 1
 }
 ```
 
-This endpoint updates the server's settings.
+This endpoint deletes a genre, removing it from all library items.
 
 ### HTTP Request
 
-`PATCH http://abs.example.com/api/settings`
+`DELETE http://abs.example.com/api/genres/<Genre>`
 
-### Parameters
+### URL Parameters
 
-Provide a [Server Settings](#server-settings) object with the key-value pairs to update.
+Parameter | Description
+--------- | -----------
+Genre | The name of the genre to delete, Base64 and URL encoded.
 
 ### Response
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
-200 | OK | Success | See below.
-403 | Forbidden | An admin user is required to update server settings. |
-500 | Internal Server Error | Invalid server settings update object. |
+200 | OK | Success | See Below
+404 | Not Found | An admin user is required to delete genres. |
 
 #### Response Schema
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`success` | Boolean | Whether the server settings were updated successfully.
-`serverSettings` | [Server Settings](#server-settings) Object | The updated server settings.
+`numItemsUpdated` | Integer | The number of library items that had their genres changed.
+
+
+## Delete a Tag
+
+```shell
+curl -X DELETE "https://abs.example.com/api/tags/VGhlIEJlc3Q%3D" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "numItemsUpdated": 1
+}
+```
+
+This endpoint deletes a tag, removing it from all library items.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/tags/<Tag>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+Tag | The name of the tag to delete, Base64 and URL encoded.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+404 | Not Found | An admin user is required to delete tags. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`numItemsUpdated` | Integer | The number of library items that had their tags changed.
+
+
+## Get All Genres
+
+```shell
+curl "https://abs.example.com/api/genres" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "genres": [
+    "Fantasy"
+  ]
+}
+```
+
+This endpoint retrieves all genres assigned to library items.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/genres`
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+404 | Not Found | An admin user is required to get all genres. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`genres` | Array of String | The requested genres.
+
+
+## Get All Tags
+
+```shell
+curl "https://abs.example.com/api/tags" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "tags": [
+    "Favorite"
+  ]
+}
+```
+
+This endpoint retrieves all tags assigned to library items.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/tags`
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+404 | Not Found | An admin user is required to get all tags. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`tags` | Array of String | The requested tags.
 
 
 ## Get Authorized User and Server Information
@@ -272,41 +270,51 @@ Attribute | Type | Description
 `serverSettings` | [Server Settings](#server-settings) Object | The server's settings.
 `Source` | String | The server's installation source.
 
-## Get All Tags
+## Rename a Genre
 
 ```shell
-curl "https://abs.example.com/api/tags" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+curl -X POST "https://abs.example.com/api/genres/rename" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"genre": "Fantasy", "newGenre": "Magic"}'
 ```
 
 > The above command returns JSON structured like this:
 
 ```json
 {
-  "tags": [
-    "Favorite"
-  ]
+  "genreMerged": false,
+  "numItemsUpdated": 1
 }
 ```
 
-This endpoint retrieves all tags assigned to library items.
+This endpoint renames an existing genre.
 
 ### HTTP Request
 
-`GET http://abs.example.com/api/tags`
+`POST http://abs.example.com/api/genres/rename`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`genre` | String | The current name of the genre.
+`newGenre` | String | The new name for the genre.
 
 ### Response
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
 200 | OK | Success | See Below
-404 | Not Found | An admin user is required to get all tags. |
+400 | Bad Request | `genre` and `newGenre` are required parameters. |
+404 | Not Found | An admin user is required to rename genres. |
 
 #### Response Schema
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`tags` | Array of String | The requested tags.
+`genreMerged` | Boolean | Whether the renamed genre was merged into another genre.
+`numItemsUpdated` | Integer | The number of library items that had their genres changed.
 
 
 ## Rename a Tag
@@ -356,170 +364,162 @@ Attribute | Type | Description
 `numItemsUpdated` | Integer | The number of library items that had their tags changed.
 
 
-## Delete a Tag
+## Update Server Settings
 
 ```shell
-curl -X DELETE "https://abs.example.com/api/tags/VGhlIEJlc3Q%3D" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "numItemsUpdated": 1
-}
-```
-
-This endpoint deletes a tag, removing it from all library items.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/tags/<Tag>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-Tag | The name of the tag to delete, Base64 and URL encoded.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-404 | Not Found | An admin user is required to delete tags. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`numItemsUpdated` | Integer | The number of library items that had their tags changed.
-
-
-## Get All Genres
-
-```shell
-curl "https://abs.example.com/api/genres" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "genres": [
-    "Fantasy"
-  ]
-}
-```
-
-This endpoint retrieves all genres assigned to library items.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/genres`
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-404 | Not Found | An admin user is required to get all genres. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`genres` | Array of String | The requested genres.
-
-
-## Rename a Genre
-
-```shell
-curl -X POST "https://abs.example.com/api/genres/rename" \
+curl -X PATCH "https://abs.example.com/api/settings" \
   -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
   -H "Content-Type: application/json" \
-  -d '{"genre": "Fantasy", "newGenre": "Magic"}'
+  -d '{"scannerFindCovers": false}'
 ```
 
 > The above command returns JSON structured like this:
 
 ```json
 {
-  "genreMerged": false,
-  "numItemsUpdated": 1
+  "success": true,
+  "serverSettings": {
+    "id": "server-settings",
+    "scannerFindCovers": false,
+    "scannerCoverProvider": "google",
+    "scannerParseSubtitle": false,
+    "scannerPreferAudioMetadata": false,
+    "scannerPreferOpfMetadata": false,
+    "scannerPreferMatchedMetadata": false,
+    "scannerDisableWatcher": true,
+    "scannerPreferOverdriveMediaMarker": false,
+    "scannerUseSingleThreadedProber": true,
+    "scannerMaxThreads": 0,
+    "scannerUseTone": false,
+    "storeCoverWithItem": false,
+    "storeMetadataWithItem": false,
+    "rateLimitLoginRequests": 10,
+    "rateLimitLoginWindow": 600000,
+    "backupSchedule": "30 1 * * *",
+    "backupsToKeep": 2,
+    "maxBackupSize": 1,
+    "backupMetadataCovers": true,
+    "loggerDailyLogsToKeep": 7,
+    "loggerScannerLogsToKeep": 2,
+    "homeBookshelfView": 1,
+    "bookshelfView": 1,
+    "sortingIgnorePrefix": false,
+    "sortingPrefixes": [
+      "the",
+      "a"
+    ],
+    "chromecastEnabled": false,
+    "enableEReader": false,
+    "dateFormat": "MM/dd/yyyy",
+    "timeFormat": "HH:mm",
+    "language": "en-us",
+    "logLevel": 2,
+    "version": "2.2.5"
+  }
 }
 ```
 
-This endpoint renames an existing genre.
+This endpoint updates the server's settings.
 
 ### HTTP Request
 
-`POST http://abs.example.com/api/genres/rename`
+`PATCH http://abs.example.com/api/settings`
 
 ### Parameters
 
-Parameter | Type | Description
---------- | ---- | -----------
-`genre` | String | The current name of the genre.
-`newGenre` | String | The new name for the genre.
+Provide a [Server Settings](#server-settings) object with the key-value pairs to update.
 
 ### Response
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
-200 | OK | Success | See Below
-400 | Bad Request | `genre` and `newGenre` are required parameters. |
-404 | Not Found | An admin user is required to rename genres. |
+200 | OK | Success | See below.
+403 | Forbidden | An admin user is required to update server settings. |
+500 | Internal Server Error | Invalid server settings update object. |
 
 #### Response Schema
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`genreMerged` | Boolean | Whether the renamed genre was merged into another genre.
-`numItemsUpdated` | Integer | The number of library items that had their genres changed.
+`success` | Boolean | Whether the server settings were updated successfully.
+`serverSettings` | [Server Settings](#server-settings) Object | The updated server settings.
 
 
-## Delete a Genre
+## Upload Files
 
 ```shell
-curl -X DELETE "https://abs.example.com/api/genres/TWFnaWM%3D" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+curl -X POST "https://abs.example.com/api/upload" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -F title="Wizard's First Rule" \
+  -F author="Terry Goodkind" \
+  -F series="Sword of Truth" \
+  -F library="lib_c1u6t4p45c35rf0nzd" \
+  -F folder="fol_bev1zuxhb0j0s1wehr" \
+  -F 0=@"Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3" \
+  -F 1=@"Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3" \
+  -F 2=@cover.jpg
 ```
 
-> The above command returns JSON structured like this:
-
-```json
-{
-  "numItemsUpdated": 1
-}
-```
-
-This endpoint deletes a genre, removing it from all library items.
+This endpoint uploads library item files to the server.
 
 ### HTTP Request
 
-`DELETE http://abs.example.com/api/genres/<Genre>`
+`POST http://abs.example.com/api/upload`
 
-### URL Parameters
+### Form Parameters
 
-Parameter | Description
---------- | -----------
-Genre | The name of the genre to delete, Base64 and URL encoded.
+Parameter | Type | Description
+--------- | ---- | -----------
+`title` | String | The library item's title.
+`author` | String | Optionally, the library item's author.
+`series` | String | Optionally, the library item's series.
+`library` | String | The ID of the library to put the item in.
+`folder` | String | The ID of the folder to put the item in.
+
+The files will be put in a directory at `<folderDir>/<author>/<series>/<title>`.
+
+The form keys for the files can be anything as they are ignored.
+
+The following file types are supported:
+
+* `.png`
+* `.jpg`
+* `.jpeg`
+* `.webp`
+* `.m4b`
+* `.mp3`
+* `.m4a`
+* `.flac`
+* `.opus`
+* `.ogg`
+* `.oga`
+* `.mp4`
+* `.aac`
+* `.wma`
+* `.aiff`
+* `.wav`
+* `.webm`
+* `.webma`
+* `.epub`
+* `.pdf`
+* `.mobi`
+* `.azw3`
+* `.cbr`
+* `.cbz`
+* `.nfo`
+* `.txt`
+* `.opf`
+* `.abs`
 
 ### Response
 
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-404 | Not Found | An admin user is required to delete genres. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`numItemsUpdated` | Integer | The number of library items that had their genres changed.
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+400 | Bad Request | No files were provided.
+403 | Forbidden | A user with upload permissions is required.
+404 | Not Found | No library with the given ID exists, or no folder with the given ID exists in the library.
+500 | Internal Server Error | No files were provided, or the upload directory already exists.
 
 
 ## Validate a Cron Expression

--- a/source/includes/_notifications.md
+++ b/source/includes/_notifications.md
@@ -1,5 +1,227 @@
 # Notifications
 
+## Create a Notification
+
+```shell
+curl -X POST "https://abs.example.com/api/notifications" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"eventName": "onPodcastEpisodeDownloaded", "urls": ["apprises://apprise.example.com/email"], "titleTemplate": "New {{podcastTitle}} Episode!", "bodyTemplate": "{{episodeTitle}} has been added to {{libraryName}} library.", "enabled": true, "type": "info"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "notification-settings",
+  "appriseType": "api",
+  "appriseApiUrl": "https://apprise.example.com/notify",
+  "notifications": [
+    {
+      "id": "noti_nod281qwkj5ow7h7fi",
+      "libraryId": null,
+      "eventName": "onPodcastEpisodeDownloaded",
+      "urls": [
+        "apprises://apprise.example.com/email"
+      ],
+      "titleTemplate": "New {{podcastTitle}} Episode!",
+      "bodyTemplate": "{{episodeTitle}} has been added to {{libraryName}} library.",
+      "enabled": true,
+      "type": "info",
+      "lastFiredAt": 1668776410792,
+      "lastAttemptFailed": false,
+      "numConsecutiveFailedAttempts": 0,
+      "numTimesFired": 5,
+      "createdAt": 1666545142424
+    }
+  ],
+  "maxFailedAttempts": 5,
+  "maxNotificationQueue": 20,
+  "notificationDelay": 1000
+}
+```
+
+This endpoint creates a notification and returns the server's updated notification settings.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/notifications`
+
+### Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`libraryId` | String or null | `null` | The ID of the library the notification is associated with.
+`eventName` | String | **Required** | The name of the event the notification will fire on.
+`urls` | Array of String | **Required** | The Apprise URLs to use for the notification.
+`titleTemplate` | String | **Required** | The template for the notification title.
+`bodyTemplate` | String | **Required** | The template for the notification body.
+`enabled` | Boolean | `false` | Whether the notification is enabled.
+`type` | String or null | `null` | The notification's type.
+
+<aside class="notice">
+The <code>urls</code> array parameter must have a non-zero length for the notification to be saved.
+</aside>
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Notification Settings](#notification-settings)
+404 | Not Found | An admin user is required create notifications. |
+
+
+## Delete a Notification
+
+```shell
+curl -X DELETE "https://abs.example.com/api/notifications/noti_nod281qwkj5ow7h7fi" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "notification-settings",
+  "appriseType": "api",
+  "appriseApiUrl": "https://apprise.example.com/notify",
+  "notifications": [],
+  "maxFailedAttempts": 5,
+  "maxNotificationQueue": 20,
+  "notificationDelay": 1000
+}
+```
+
+This endpoint deletes a notification and returns the server's updated notification settings.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/notifications/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the notification.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Notification Settings](#notification-settings)
+404 | Not Found | An admin user is required delete notifications, or no notification with the given ID exists. |
+
+
+## Fire Test Notification Event
+
+```shell
+curl "https://abs.example.com/api/notifications/test" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint fires the test notification event.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/notifications/test`
+
+### Optional Query Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`fail` | Binary | Whether to intentionally cause the notification to fail. `0` for false, `1` for true.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+404 | Not Found | An admin user is required to fire notification events.
+
+
+## Get Notification Event Data
+
+```shell
+curl "https://abs.example.com/api/notificationdata" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "events": [
+    {
+      "name": "onPodcastEpisodeDownloaded",
+      "requiresLibrary": true,
+      "libraryMediaType": "podcast",
+      "description": "Triggered when a podcast episode is auto-downloaded",
+      "variables": [
+        "libraryItemId",
+        "libraryId",
+        "libraryName",
+        "mediaTags",
+        "podcastTitle",
+        "podcastAuthor",
+        "podcastDescription",
+        "podcastGenres",
+        "episodeId",
+        "episodeTitle",
+        "episodeSubtitle",
+        "episodeDescription"
+      ],
+      "defaults": {
+        "title": "New {{podcastTitle}} Episode!",
+        "body": "{{episodeTitle}} has been added to {{libraryName}} library."
+      },
+      "testData": {
+        "libraryItemId": "li_notification_test",
+        "libraryId": "lib_test",
+        "libraryName": "Podcasts",
+        "podcastTitle": "Abs Test Podcast",
+        "episodeId": "ep_notification_test",
+        "episodeTitle": "Successful Test"
+      }
+    },
+    {
+      "name": "onTest",
+      "requiresLibrary": false,
+      "description": "Event for testing the notification system",
+      "variables": [
+        "version"
+      ],
+      "defaults": {
+        "title": "Test Notification on Abs {{version}}",
+        "body": "Test notificataion body for abs {{version}}."
+      },
+      "testData": {
+        "version": "v2.2.5"
+      }
+    }
+  ]
+}
+```
+
+This endpoint retrieves the server's notification event data.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/notificationdata`
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+404 | Not Found | An admin user is required get notification event data. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`events` | Array of [Notification Event](#notification-event) | The notification event data.
+
+
 ## Get Notification Settings
 
 ```shell
@@ -113,6 +335,33 @@ Attribute | Type | Description
 `settings` | [Notification Settings](#notification-settings) Object | The notification settings of the server.
 
 
+## Send Notification Test
+
+```shell
+curl "https://abs.example.com/api/notifications/noti_nod281qwkj5ow7h7fi/test" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint sends a test to the given notification.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/notifications/<ID>/test`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the notification.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+404 | Not Found | An admin user is required to send notification tests, or no notification with the given ID exists.
+500 | Internal Server Error | The Apprise URL is not set, or the notification failed to send.
+
 ## Update Notification Settings
 
 ```shell
@@ -140,228 +389,6 @@ Status | Meaning | Description
 ------ | ------- | -----------
 200 | OK | Success
 404 | Not Found | An admin user is required to update notification settings.
-
-
-## Get Notification Event Data
-
-```shell
-curl "https://abs.example.com/api/notificationdata" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "events": [
-    {
-      "name": "onPodcastEpisodeDownloaded",
-      "requiresLibrary": true,
-      "libraryMediaType": "podcast",
-      "description": "Triggered when a podcast episode is auto-downloaded",
-      "variables": [
-        "libraryItemId",
-        "libraryId",
-        "libraryName",
-        "mediaTags",
-        "podcastTitle",
-        "podcastAuthor",
-        "podcastDescription",
-        "podcastGenres",
-        "episodeId",
-        "episodeTitle",
-        "episodeSubtitle",
-        "episodeDescription"
-      ],
-      "defaults": {
-        "title": "New {{podcastTitle}} Episode!",
-        "body": "{{episodeTitle}} has been added to {{libraryName}} library."
-      },
-      "testData": {
-        "libraryItemId": "li_notification_test",
-        "libraryId": "lib_test",
-        "libraryName": "Podcasts",
-        "podcastTitle": "Abs Test Podcast",
-        "episodeId": "ep_notification_test",
-        "episodeTitle": "Successful Test"
-      }
-    },
-    {
-      "name": "onTest",
-      "requiresLibrary": false,
-      "description": "Event for testing the notification system",
-      "variables": [
-        "version"
-      ],
-      "defaults": {
-        "title": "Test Notification on Abs {{version}}",
-        "body": "Test notificataion body for abs {{version}}."
-      },
-      "testData": {
-        "version": "v2.2.5"
-      }
-    }
-  ]
-}
-```
-
-This endpoint retrieves the server's notification event data.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/notificationdata`
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-404 | Not Found | An admin user is required get notification event data. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`events` | Array of [Notification Event](#notification-event) | The notification event data.
-
-
-## Fire Test Notification Event
-
-```shell
-curl "https://abs.example.com/api/notifications/test" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint fires the test notification event.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/notifications/test`
-
-### Optional Query Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`fail` | Binary | Whether to intentionally cause the notification to fail. `0` for false, `1` for true.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-404 | Not Found | An admin user is required to fire notification events.
-
-
-## Create a Notification
-
-```shell
-curl -X POST "https://abs.example.com/api/notifications" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"eventName": "onPodcastEpisodeDownloaded", "urls": ["apprises://apprise.example.com/email"], "titleTemplate": "New {{podcastTitle}} Episode!", "bodyTemplate": "{{episodeTitle}} has been added to {{libraryName}} library.", "enabled": true, "type": "info"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "notification-settings",
-  "appriseType": "api",
-  "appriseApiUrl": "https://apprise.example.com/notify",
-  "notifications": [
-    {
-      "id": "noti_nod281qwkj5ow7h7fi",
-      "libraryId": null,
-      "eventName": "onPodcastEpisodeDownloaded",
-      "urls": [
-        "apprises://apprise.example.com/email"
-      ],
-      "titleTemplate": "New {{podcastTitle}} Episode!",
-      "bodyTemplate": "{{episodeTitle}} has been added to {{libraryName}} library.",
-      "enabled": true,
-      "type": "info",
-      "lastFiredAt": 1668776410792,
-      "lastAttemptFailed": false,
-      "numConsecutiveFailedAttempts": 0,
-      "numTimesFired": 5,
-      "createdAt": 1666545142424
-    }
-  ],
-  "maxFailedAttempts": 5,
-  "maxNotificationQueue": 20,
-  "notificationDelay": 1000
-}
-```
-
-This endpoint creates a notification and returns the server's updated notification settings.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/notifications`
-
-### Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`libraryId` | String or null | `null` | The ID of the library the notification is associated with.
-`eventName` | String | **Required** | The name of the event the notification will fire on.
-`urls` | Array of String | **Required** | The Apprise URLs to use for the notification.
-`titleTemplate` | String | **Required** | The template for the notification title.
-`bodyTemplate` | String | **Required** | The template for the notification body.
-`enabled` | Boolean | `false` | Whether the notification is enabled.
-`type` | String or null | `null` | The notification's type.
-
-<aside class="notice">
-The <code>urls</code> array parameter must have a non-zero length for the notification to be saved.
-</aside>
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Notification Settings](#notification-settings)
-404 | Not Found | An admin user is required create notifications. |
-
-
-## Delete a Notification
-
-```shell
-curl -X DELETE "https://abs.example.com/api/notifications/noti_nod281qwkj5ow7h7fi" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "notification-settings",
-  "appriseType": "api",
-  "appriseApiUrl": "https://apprise.example.com/notify",
-  "notifications": [],
-  "maxFailedAttempts": 5,
-  "maxNotificationQueue": 20,
-  "notificationDelay": 1000
-}
-```
-
-This endpoint deletes a notification and returns the server's updated notification settings.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/notifications/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the notification.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Notification Settings](#notification-settings)
-404 | Not Found | An admin user is required delete notifications, or no notification with the given ID exists. |
 
 
 ## Update a Notification
@@ -440,31 +467,3 @@ Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
 200 | OK | Success | [Notification Settings](#notification-settings)
 404 | Not Found | An admin user is required update notifications, or no notification with the given ID exists. |
-
-
-## Send Notification Test
-
-```shell
-curl "https://abs.example.com/api/notifications/noti_nod281qwkj5ow7h7fi/test" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint sends a test to the given notification.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/notifications/<ID>/test`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the notification.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-404 | Not Found | An admin user is required to send notification tests, or no notification with the given ID exists.
-500 | Internal Server Error | The Apprise URL is not set, or the notification failed to send.

--- a/source/includes/_playlists.md
+++ b/source/includes/_playlists.md
@@ -1,5 +1,695 @@
 # Playlists
 
+## Add an Item to a Playlist
+
+```shell
+curl -X POST "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu/item" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"libraryItemId": "li_8gch9ve09orgn4fdz8"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "pl_qbwet64998s5ra6dcu",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "The Best Books",
+  "description": null,
+  "coverPath": null,
+  "items": [
+    {
+      "libraryItemId": "li_8gch9ve09orgn4fdz8",
+      "episodeId": null,
+      "libraryItem": {
+        "id": "li_8gch9ve09orgn4fdz8",
+        "ino": "649641337522215266",
+        "libraryId": "lib_c1u6t4p45c35rf0nzd",
+        "folderId": "fol_bev1zuxhb0j0s1wehr",
+        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
+        "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
+        "isFile": false,
+        "mtimeMs": 1650621074299,
+        "ctimeMs": 1650621074299,
+        "birthtimeMs": 0,
+        "addedAt": 1650621073750,
+        "updatedAt": 1650621110769,
+        "lastScan": 1651830827825,
+        "scanVersion": "2.0.21",
+        "isMissing": false,
+        "isInvalid": false,
+        "mediaType": "book",
+        "media": {
+          "libraryItemId": "li_8gch9ve09orgn4fdz8",
+          "metadata": {
+            "title": "Wizards First Rule",
+            "titleIgnorePrefix": "Wizards First Rule",
+            "subtitle": null,
+            "authors": [
+              {
+                "id": "aut_z3leimgybl7uf3y4ab",
+                "name": "Terry Goodkind"
+              }
+            ],
+            "narrators": [
+              "Sam Tsoutsouvas"
+            ],
+            "series": [
+              {
+                "id": "ser_cabkj4jeu8be3rap4g",
+                "name": "Sword of Truth",
+                "sequence": "1"
+              }
+            ],
+            "genres": [
+              "Fantasy"
+            ],
+            "publishedYear": "2008",
+            "publishedDate": null,
+            "publisher": "Brilliance Audio",
+            "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+            "isbn": null,
+            "asin": "B002V0QK4C",
+            "language": null,
+            "explicit": false,
+            "authorName": "Terry Goodkind",
+            "authorNameLF": "Goodkind, Terry",
+            "narratorName": "Sam Tsoutsouvas",
+            "seriesName": "Sword of Truth"
+          },
+          "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+          "tags": [
+            "Favorite"
+          ],
+          "audioFiles": [
+            {
+              "index": 1,
+              "ino": "649644248522215260",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "size": 48037888,
+                "mtimeMs": 1632223180278,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              },
+              "addedAt": 1650621074131,
+              "updatedAt": 1651830828023,
+              "trackNumFromMeta": 1,
+              "discNumFromMeta": null,
+              "trackNumFromFilename": 1,
+              "discNumFromFilename": null,
+              "manuallyVerified": false,
+              "invalid": false,
+              "exclude": false,
+              "error": null,
+              "format": "MP2/3 (MPEG audio layer 2/3)",
+              "duration": 6004.6675,
+              "bitRate": 64000,
+              "language": null,
+              "codec": "mp3",
+              "timeBase": "1/14112000",
+              "channels": 2,
+              "channelLayout": "stereo",
+              "chapters": [],
+              "embeddedCoverArt": null,
+              "metaTags": {
+                "tagAlbum": "SOT Bk01",
+                "tagArtist": "Terry Goodkind",
+                "tagGenre": "Audiobook Fantasy",
+                "tagTitle": "Wizards First Rule 01",
+                "tagTrack": "01/20",
+                "tagAlbumArtist": "Terry Goodkind",
+                "tagComposer": "Terry Goodkind"
+              },
+              "mimeType": "audio/mpeg"
+            },
+            {
+              "index": 2,
+              "ino": "649644248522215261",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "size": 47972352,
+                "mtimeMs": 1632223180281,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              },
+              "addedAt": 1650621074130,
+              "updatedAt": 1651830828023,
+              "trackNumFromMeta": 2,
+              "discNumFromMeta": null,
+              "trackNumFromFilename": 1,
+              "discNumFromFilename": null,
+              "manuallyVerified": false,
+              "invalid": false,
+              "exclude": false,
+              "error": null,
+              "format": "MP2/3 (MPEG audio layer 2/3)",
+              "duration": 5996.2785,
+              "bitRate": 64000,
+              "language": null,
+              "codec": "mp3",
+              "timeBase": "1/14112000",
+              "channels": 2,
+              "channelLayout": "stereo",
+              "chapters": [],
+              "embeddedCoverArt": null,
+              "metaTags": {
+                "tagAlbum": "SOT Bk01",
+                "tagArtist": "Terry Goodkind",
+                "tagGenre": "Audiobook Fantasy",
+                "tagTitle": "Wizards First Rule 02",
+                "tagTrack": "02/20",
+                "tagAlbumArtist": "Terry Goodkind",
+                "tagComposer": "Terry Goodkind"
+              },
+              "mimeType": "audio/mpeg"
+            }
+          ],
+          "chapters": [
+            {
+              "id": 0,
+              "start": 0,
+              "end": 6004.6675,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
+            },
+            {
+              "id": 1,
+              "start": 6004.6675,
+              "end": 12000.946,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
+            }
+          ],
+          "duration": 33854.905,
+          "size": 268824228,
+          "tracks": [
+            {
+              "index": 1,
+              "startOffset": 0,
+              "duration": 6004.6675,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "mimeType": "audio/mpeg",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "size": 48037888,
+                "mtimeMs": 1632223180278,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              }
+            },
+            {
+              "index": 2,
+              "startOffset": 6004.6675,
+              "duration": 5996.2785,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "mimeType": "audio/mpeg",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
+                "size": 47972352,
+                "mtimeMs": 1632223180281,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              }
+            }
+          ],
+          "missingParts": [],
+          "ebookFile": null
+        },
+        "libraryFiles": [
+          {
+            "ino": "649644248522215260",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "size": 48037888,
+              "mtimeMs": 1632223180278,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621052494,
+            "updatedAt": 1650621052494,
+            "fileType": "audio"
+          },
+          {
+            "ino": "649644248522215261",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "size": 47972352,
+              "mtimeMs": 1632223180281,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621052494,
+            "updatedAt": 1650621052494,
+            "fileType": "audio"
+          },
+          {
+            "ino": "649644248522215267",
+            "metadata": {
+              "filename": "cover.jpg",
+              "ext": ".jpg",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+              "relPath": "cover.jpg",
+              "size": 325531,
+              "mtimeMs": 1638754803540,
+              "ctimeMs": 1645978261003,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621052495,
+            "updatedAt": 1650621052495,
+            "fileType": "image"
+          }
+        ],
+        "size": 268990279
+      }
+    }
+  ],
+  "lastUpdate": 1669623431313,
+  "createdAt": 1669623431313
+}
+```
+
+This endpoint adds an item to a playlist and returns the updated playlist.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/playlists/<ID>/item`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the playlist.
+
+### Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`libraryItemId` | String | **Required** | The ID of the library item the playlist item is for.
+`episodeId` | String or null | `null` | The ID of the podcast episode the playlist item is for.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Playlist Expanded](#playlist-expanded)
+400 | Bad Request | No library item with the provided ID exists, the library item is in a different library from the playlist, the library item is already in the playlist, the library item is not a podcast and an `episodeId` was provided, the library item is a podcast and an `episodeId` was not provided, or no podcast episode with the provided ID exists in the library item. |
+403 | Forbidden | The playlist does not belong to the authenticated user. |
+404 | Not Found | No playlist with the provided ID exists. |
+
+
+## Batch Add Items to a Playlist
+
+```shell
+curl -X POST "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu/batch/add" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"items": [{"libraryItemId": "li_8gch9ve09orgn4fdz8"}]}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "pl_qbwet64998s5ra6dcu",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "The Best Books",
+  "description": null,
+  "coverPath": null,
+  "items": [
+    {
+      "libraryItemId": "li_8gch9ve09orgn4fdz8",
+      "episodeId": null,
+      "libraryItem": {
+        "id": "li_8gch9ve09orgn4fdz8",
+        "ino": "649641337522215266",
+        "libraryId": "lib_c1u6t4p45c35rf0nzd",
+        "folderId": "fol_bev1zuxhb0j0s1wehr",
+        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
+        "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
+        "isFile": false,
+        "mtimeMs": 1650621074299,
+        "ctimeMs": 1650621074299,
+        "birthtimeMs": 0,
+        "addedAt": 1650621073750,
+        "updatedAt": 1650621110769,
+        "lastScan": 1651830827825,
+        "scanVersion": "2.0.21",
+        "isMissing": false,
+        "isInvalid": false,
+        "mediaType": "book",
+        "media": {
+          "libraryItemId": "li_8gch9ve09orgn4fdz8",
+          "metadata": {
+            "title": "Wizards First Rule",
+            "titleIgnorePrefix": "Wizards First Rule",
+            "subtitle": null,
+            "authors": [
+              {
+                "id": "aut_z3leimgybl7uf3y4ab",
+                "name": "Terry Goodkind"
+              }
+            ],
+            "narrators": [
+              "Sam Tsoutsouvas"
+            ],
+            "series": [
+              {
+                "id": "ser_cabkj4jeu8be3rap4g",
+                "name": "Sword of Truth",
+                "sequence": "1"
+              }
+            ],
+            "genres": [
+              "Fantasy"
+            ],
+            "publishedYear": "2008",
+            "publishedDate": null,
+            "publisher": "Brilliance Audio",
+            "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+            "isbn": null,
+            "asin": "B002V0QK4C",
+            "language": null,
+            "explicit": false,
+            "authorName": "Terry Goodkind",
+            "authorNameLF": "Goodkind, Terry",
+            "narratorName": "Sam Tsoutsouvas",
+            "seriesName": "Sword of Truth"
+          },
+          "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+          "tags": [
+            "Favorite"
+          ],
+          "audioFiles": [
+            {
+              "index": 1,
+              "ino": "649644248522215260",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "size": 48037888,
+                "mtimeMs": 1632223180278,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              },
+              "addedAt": 1650621074131,
+              "updatedAt": 1651830828023,
+              "trackNumFromMeta": 1,
+              "discNumFromMeta": null,
+              "trackNumFromFilename": 1,
+              "discNumFromFilename": null,
+              "manuallyVerified": false,
+              "invalid": false,
+              "exclude": false,
+              "error": null,
+              "format": "MP2/3 (MPEG audio layer 2/3)",
+              "duration": 6004.6675,
+              "bitRate": 64000,
+              "language": null,
+              "codec": "mp3",
+              "timeBase": "1/14112000",
+              "channels": 2,
+              "channelLayout": "stereo",
+              "chapters": [],
+              "embeddedCoverArt": null,
+              "metaTags": {
+                "tagAlbum": "SOT Bk01",
+                "tagArtist": "Terry Goodkind",
+                "tagGenre": "Audiobook Fantasy",
+                "tagTitle": "Wizards First Rule 01",
+                "tagTrack": "01/20",
+                "tagAlbumArtist": "Terry Goodkind",
+                "tagComposer": "Terry Goodkind"
+              },
+              "mimeType": "audio/mpeg"
+            },
+            {
+              "index": 2,
+              "ino": "649644248522215261",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "size": 47972352,
+                "mtimeMs": 1632223180281,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              },
+              "addedAt": 1650621074130,
+              "updatedAt": 1651830828023,
+              "trackNumFromMeta": 2,
+              "discNumFromMeta": null,
+              "trackNumFromFilename": 1,
+              "discNumFromFilename": null,
+              "manuallyVerified": false,
+              "invalid": false,
+              "exclude": false,
+              "error": null,
+              "format": "MP2/3 (MPEG audio layer 2/3)",
+              "duration": 5996.2785,
+              "bitRate": 64000,
+              "language": null,
+              "codec": "mp3",
+              "timeBase": "1/14112000",
+              "channels": 2,
+              "channelLayout": "stereo",
+              "chapters": [],
+              "embeddedCoverArt": null,
+              "metaTags": {
+                "tagAlbum": "SOT Bk01",
+                "tagArtist": "Terry Goodkind",
+                "tagGenre": "Audiobook Fantasy",
+                "tagTitle": "Wizards First Rule 02",
+                "tagTrack": "02/20",
+                "tagAlbumArtist": "Terry Goodkind",
+                "tagComposer": "Terry Goodkind"
+              },
+              "mimeType": "audio/mpeg"
+            }
+          ],
+          "chapters": [
+            {
+              "id": 0,
+              "start": 0,
+              "end": 6004.6675,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
+            },
+            {
+              "id": 1,
+              "start": 6004.6675,
+              "end": 12000.946,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
+            }
+          ],
+          "duration": 33854.905,
+          "size": 268824228,
+          "tracks": [
+            {
+              "index": 1,
+              "startOffset": 0,
+              "duration": 6004.6675,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "mimeType": "audio/mpeg",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "size": 48037888,
+                "mtimeMs": 1632223180278,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              }
+            },
+            {
+              "index": 2,
+              "startOffset": 6004.6675,
+              "duration": 5996.2785,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "mimeType": "audio/mpeg",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
+                "size": 47972352,
+                "mtimeMs": 1632223180281,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              }
+            }
+          ],
+          "missingParts": [],
+          "ebookFile": null
+        },
+        "libraryFiles": [
+          {
+            "ino": "649644248522215260",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "size": 48037888,
+              "mtimeMs": 1632223180278,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621052494,
+            "updatedAt": 1650621052494,
+            "fileType": "audio"
+          },
+          {
+            "ino": "649644248522215261",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "size": 47972352,
+              "mtimeMs": 1632223180281,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621052494,
+            "updatedAt": 1650621052494,
+            "fileType": "audio"
+          },
+          {
+            "ino": "649644248522215267",
+            "metadata": {
+              "filename": "cover.jpg",
+              "ext": ".jpg",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+              "relPath": "cover.jpg",
+              "size": 325531,
+              "mtimeMs": 1638754803540,
+              "ctimeMs": 1645978261003,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621052495,
+            "updatedAt": 1650621052495,
+            "fileType": "image"
+          }
+        ],
+        "size": 268990279
+      }
+    }
+  ],
+  "lastUpdate": 1669623431313,
+  "createdAt": 1669623431313
+}
+```
+
+This endpoint batch adds items to a playlist and returns the updated playlist.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/playlists/<ID>/batch/add`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the playlist.
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`items` | Array of [Playlist Item](#playlist-item) | The items to add to the playlist.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Playlist Expanded](#playlist-expanded)
+400 | Bad Request | One or more of the provided items does not have a `libraryItemId`. |
+403 | Forbidden | The playlist does not belong to the authenticated user. |
+404 | Not Found | No playlist with the provided ID exists. |
+500 | Internal Server Error | The provided `items` array was empty or did not exist. |
+
+
+## Batch Remove Items From a Playlist
+
+```shell
+curl -X POST "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu/batch/remove" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"items": [{"libraryItemId": "li_8gch9ve09orgn4fdz8"}]}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "pl_qbwet64998s5ra6dcu",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "The Best Books",
+  "description": null,
+  "coverPath": null,
+  "items": [],
+  "lastUpdate": 1669623431313,
+  "createdAt": 1669623431313
+}
+```
+
+This endpoint batch removes items from a playlist and returns the updated playlist. Then, if the playlist is empty, it will be deleted.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/playlists/<ID>/batch/remove`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the playlist.
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`items` | Array of [Playlist Item](#playlist-item) | The items to remove from the playlist.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Playlist Expanded](#playlist-expanded)
+400 | Bad Request | One or more of the provided items does not have a `libraryItemId`. |
+403 | Forbidden | The playlist does not belong to the authenticated user. |
+404 | Not Found | No playlist with the provided ID exists. |
+500 | Internal Server Error | The provided `items` array was empty or did not exist. |
+
+
 ## Create a Playlist
 
 ```shell
@@ -311,6 +1001,341 @@ Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
 200 | OK | Success | [Playlist Expanded](#playlist-expanded)
 400 | Bad Request | The provided playlist data was invalid. |
+
+
+## Create a Playlist From a Collection
+
+```shell
+curl -X POST "https://abs.example.com/api/playlists/collection/col_fpfstanv6gd7tq2qz7" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "pl_qbwet64998s5ra6dcu",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "Favorites",
+  "description": null,
+  "coverPath": null,
+  "items": [
+    {
+      "libraryItemId": "li_8gch9ve09orgn4fdz8",
+      "episodeId": null,
+      "libraryItem": {
+        "id": "li_8gch9ve09orgn4fdz8",
+        "ino": "649641337522215266",
+        "libraryId": "lib_c1u6t4p45c35rf0nzd",
+        "folderId": "fol_bev1zuxhb0j0s1wehr",
+        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
+        "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
+        "isFile": false,
+        "mtimeMs": 1650621074299,
+        "ctimeMs": 1650621074299,
+        "birthtimeMs": 0,
+        "addedAt": 1650621073750,
+        "updatedAt": 1650621110769,
+        "lastScan": 1651830827825,
+        "scanVersion": "2.0.21",
+        "isMissing": false,
+        "isInvalid": false,
+        "mediaType": "book",
+        "media": {
+          "libraryItemId": "li_8gch9ve09orgn4fdz8",
+          "metadata": {
+            "title": "Wizards First Rule",
+            "titleIgnorePrefix": "Wizards First Rule",
+            "subtitle": null,
+            "authors": [
+              {
+                "id": "aut_z3leimgybl7uf3y4ab",
+                "name": "Terry Goodkind"
+              }
+            ],
+            "narrators": [
+              "Sam Tsoutsouvas"
+            ],
+            "series": [
+              {
+                "id": "ser_cabkj4jeu8be3rap4g",
+                "name": "Sword of Truth",
+                "sequence": "1"
+              }
+            ],
+            "genres": [
+              "Fantasy"
+            ],
+            "publishedYear": "2008",
+            "publishedDate": null,
+            "publisher": "Brilliance Audio",
+            "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+            "isbn": null,
+            "asin": "B002V0QK4C",
+            "language": null,
+            "explicit": false,
+            "authorName": "Terry Goodkind",
+            "authorNameLF": "Goodkind, Terry",
+            "narratorName": "Sam Tsoutsouvas",
+            "seriesName": "Sword of Truth"
+          },
+          "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+          "tags": [
+            "Favorite"
+          ],
+          "audioFiles": [
+            {
+              "index": 1,
+              "ino": "649644248522215260",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "size": 48037888,
+                "mtimeMs": 1632223180278,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              },
+              "addedAt": 1650621074131,
+              "updatedAt": 1651830828023,
+              "trackNumFromMeta": 1,
+              "discNumFromMeta": null,
+              "trackNumFromFilename": 1,
+              "discNumFromFilename": null,
+              "manuallyVerified": false,
+              "invalid": false,
+              "exclude": false,
+              "error": null,
+              "format": "MP2/3 (MPEG audio layer 2/3)",
+              "duration": 6004.6675,
+              "bitRate": 64000,
+              "language": null,
+              "codec": "mp3",
+              "timeBase": "1/14112000",
+              "channels": 2,
+              "channelLayout": "stereo",
+              "chapters": [],
+              "embeddedCoverArt": null,
+              "metaTags": {
+                "tagAlbum": "SOT Bk01",
+                "tagArtist": "Terry Goodkind",
+                "tagGenre": "Audiobook Fantasy",
+                "tagTitle": "Wizards First Rule 01",
+                "tagTrack": "01/20",
+                "tagAlbumArtist": "Terry Goodkind",
+                "tagComposer": "Terry Goodkind"
+              },
+              "mimeType": "audio/mpeg"
+            },
+            {
+              "index": 2,
+              "ino": "649644248522215261",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "size": 47972352,
+                "mtimeMs": 1632223180281,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              },
+              "addedAt": 1650621074130,
+              "updatedAt": 1651830828023,
+              "trackNumFromMeta": 2,
+              "discNumFromMeta": null,
+              "trackNumFromFilename": 1,
+              "discNumFromFilename": null,
+              "manuallyVerified": false,
+              "invalid": false,
+              "exclude": false,
+              "error": null,
+              "format": "MP2/3 (MPEG audio layer 2/3)",
+              "duration": 5996.2785,
+              "bitRate": 64000,
+              "language": null,
+              "codec": "mp3",
+              "timeBase": "1/14112000",
+              "channels": 2,
+              "channelLayout": "stereo",
+              "chapters": [],
+              "embeddedCoverArt": null,
+              "metaTags": {
+                "tagAlbum": "SOT Bk01",
+                "tagArtist": "Terry Goodkind",
+                "tagGenre": "Audiobook Fantasy",
+                "tagTitle": "Wizards First Rule 02",
+                "tagTrack": "02/20",
+                "tagAlbumArtist": "Terry Goodkind",
+                "tagComposer": "Terry Goodkind"
+              },
+              "mimeType": "audio/mpeg"
+            }
+          ],
+          "chapters": [
+            {
+              "id": 0,
+              "start": 0,
+              "end": 6004.6675,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
+            },
+            {
+              "id": 1,
+              "start": 6004.6675,
+              "end": 12000.946,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
+            }
+          ],
+          "duration": 33854.905,
+          "size": 268824228,
+          "tracks": [
+            {
+              "index": 1,
+              "startOffset": 0,
+              "duration": 6004.6675,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "mimeType": "audio/mpeg",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+                "size": 48037888,
+                "mtimeMs": 1632223180278,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              }
+            },
+            {
+              "index": 2,
+              "startOffset": 6004.6675,
+              "duration": 5996.2785,
+              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "mimeType": "audio/mpeg",
+              "metadata": {
+                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "ext": ".mp3",
+                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
+                "size": 47972352,
+                "mtimeMs": 1632223180281,
+                "ctimeMs": 1645978261001,
+                "birthtimeMs": 0
+              }
+            }
+          ],
+          "missingParts": [],
+          "ebookFile": null
+        },
+        "libraryFiles": [
+          {
+            "ino": "649644248522215260",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+              "size": 48037888,
+              "mtimeMs": 1632223180278,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621052494,
+            "updatedAt": 1650621052494,
+            "fileType": "audio"
+          },
+          {
+            "ino": "649644248522215261",
+            "metadata": {
+              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "ext": ".mp3",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
+              "size": 47972352,
+              "mtimeMs": 1632223180281,
+              "ctimeMs": 1645978261001,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621052494,
+            "updatedAt": 1650621052494,
+            "fileType": "audio"
+          },
+          {
+            "ino": "649644248522215267",
+            "metadata": {
+              "filename": "cover.jpg",
+              "ext": ".jpg",
+              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+              "relPath": "cover.jpg",
+              "size": 325531,
+              "mtimeMs": 1638754803540,
+              "ctimeMs": 1645978261003,
+              "birthtimeMs": 0
+            },
+            "addedAt": 1650621052495,
+            "updatedAt": 1650621052495,
+            "fileType": "image"
+          }
+        ],
+        "size": 268990279
+      }
+    }
+  ],
+  "lastUpdate": 1669623431313,
+  "createdAt": 1669623431313
+}
+```
+
+This endpoint creates a playlist from a collection. The newly created playlist is returned.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/playlists/collection/<CollectionID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+CollectionID | The ID of the collection.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Playlist Expanded](#playlist-expanded)
+400 | Bad Request | The user cannot access any books contained in the collection. |
+404 | Not Found | No collection with the given ID exists. |
+
+## Delete a Playlist
+
+```shell
+curl -X DELETE "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint deletes a playlist.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/playlists/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the playlist.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | The playlist does not belong to the authenticated user.
+404 | Not Found | No playlist with the provided ID exists.
 
 
 ## Get All User Playlists
@@ -931,6 +1956,53 @@ Status | Meaning | Description | Schema
 404 | Not Found | No playlist with the provided ID exists. |
 
 
+## Remove an Item From a Playlist
+
+```shell
+curl -X DELETE "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu/item/li_8gch9ve09orgn4fdz8" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "pl_qbwet64998s5ra6dcu",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "The Best Books",
+  "description": null,
+  "coverPath": null,
+  "items": [],
+  "lastUpdate": 1669623431313,
+  "createdAt": 1669623431313
+}
+```
+
+This endpoint removes an item from a playlist and returns the updated playlist. Then, if the playlist is empty, it will be deleted.
+
+### HTTP Request
+
+* `DELETE http://abs.example.com/api/playlists/<ID>/item/<LibraryItemID>`
+* `DELETE http://abs.example.com/api/playlists/<ID>/item/<LibraryItemID>/<EpisodeID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the playlist.
+LibraryItemID | The ID of the library item the playlist item to remove is for.
+EpisodeID | The ID of the podcast episode the playlist item to remove is for.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Playlist Expanded](#playlist-expanded)
+403 | Forbidden | The playlist does not belong to the authenticated user. |
+404 | Not Found | No playlist with the provided ID exists, or the playlist does not contain the provided item. |
+
+
 ## Update a Playlist
 
 ```shell
@@ -1248,1076 +2320,3 @@ Status | Meaning | Description | Schema
 200 | OK | Success | [Playlist Expanded](#playlist-expanded)
 403 | Forbidden | The playlist does not belong to the authenticated user. |
 404 | Not Found | No playlist with the provided ID exists. |
-
-
-## Delete a Playlist
-
-```shell
-curl -X DELETE "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint deletes a playlist.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/playlists/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the playlist.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | The playlist does not belong to the authenticated user.
-404 | Not Found | No playlist with the provided ID exists.
-
-
-## Add an Item to a Playlist
-
-```shell
-curl -X POST "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu/item" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"libraryItemId": "li_8gch9ve09orgn4fdz8"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "pl_qbwet64998s5ra6dcu",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "The Best Books",
-  "description": null,
-  "coverPath": null,
-  "items": [
-    {
-      "libraryItemId": "li_8gch9ve09orgn4fdz8",
-      "episodeId": null,
-      "libraryItem": {
-        "id": "li_8gch9ve09orgn4fdz8",
-        "ino": "649641337522215266",
-        "libraryId": "lib_c1u6t4p45c35rf0nzd",
-        "folderId": "fol_bev1zuxhb0j0s1wehr",
-        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
-        "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
-        "isFile": false,
-        "mtimeMs": 1650621074299,
-        "ctimeMs": 1650621074299,
-        "birthtimeMs": 0,
-        "addedAt": 1650621073750,
-        "updatedAt": 1650621110769,
-        "lastScan": 1651830827825,
-        "scanVersion": "2.0.21",
-        "isMissing": false,
-        "isInvalid": false,
-        "mediaType": "book",
-        "media": {
-          "libraryItemId": "li_8gch9ve09orgn4fdz8",
-          "metadata": {
-            "title": "Wizards First Rule",
-            "titleIgnorePrefix": "Wizards First Rule",
-            "subtitle": null,
-            "authors": [
-              {
-                "id": "aut_z3leimgybl7uf3y4ab",
-                "name": "Terry Goodkind"
-              }
-            ],
-            "narrators": [
-              "Sam Tsoutsouvas"
-            ],
-            "series": [
-              {
-                "id": "ser_cabkj4jeu8be3rap4g",
-                "name": "Sword of Truth",
-                "sequence": "1"
-              }
-            ],
-            "genres": [
-              "Fantasy"
-            ],
-            "publishedYear": "2008",
-            "publishedDate": null,
-            "publisher": "Brilliance Audio",
-            "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-            "isbn": null,
-            "asin": "B002V0QK4C",
-            "language": null,
-            "explicit": false,
-            "authorName": "Terry Goodkind",
-            "authorNameLF": "Goodkind, Terry",
-            "narratorName": "Sam Tsoutsouvas",
-            "seriesName": "Sword of Truth"
-          },
-          "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-          "tags": [
-            "Favorite"
-          ],
-          "audioFiles": [
-            {
-              "index": 1,
-              "ino": "649644248522215260",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "size": 48037888,
-                "mtimeMs": 1632223180278,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              },
-              "addedAt": 1650621074131,
-              "updatedAt": 1651830828023,
-              "trackNumFromMeta": 1,
-              "discNumFromMeta": null,
-              "trackNumFromFilename": 1,
-              "discNumFromFilename": null,
-              "manuallyVerified": false,
-              "invalid": false,
-              "exclude": false,
-              "error": null,
-              "format": "MP2/3 (MPEG audio layer 2/3)",
-              "duration": 6004.6675,
-              "bitRate": 64000,
-              "language": null,
-              "codec": "mp3",
-              "timeBase": "1/14112000",
-              "channels": 2,
-              "channelLayout": "stereo",
-              "chapters": [],
-              "embeddedCoverArt": null,
-              "metaTags": {
-                "tagAlbum": "SOT Bk01",
-                "tagArtist": "Terry Goodkind",
-                "tagGenre": "Audiobook Fantasy",
-                "tagTitle": "Wizards First Rule 01",
-                "tagTrack": "01/20",
-                "tagAlbumArtist": "Terry Goodkind",
-                "tagComposer": "Terry Goodkind"
-              },
-              "mimeType": "audio/mpeg"
-            },
-            {
-              "index": 2,
-              "ino": "649644248522215261",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "size": 47972352,
-                "mtimeMs": 1632223180281,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              },
-              "addedAt": 1650621074130,
-              "updatedAt": 1651830828023,
-              "trackNumFromMeta": 2,
-              "discNumFromMeta": null,
-              "trackNumFromFilename": 1,
-              "discNumFromFilename": null,
-              "manuallyVerified": false,
-              "invalid": false,
-              "exclude": false,
-              "error": null,
-              "format": "MP2/3 (MPEG audio layer 2/3)",
-              "duration": 5996.2785,
-              "bitRate": 64000,
-              "language": null,
-              "codec": "mp3",
-              "timeBase": "1/14112000",
-              "channels": 2,
-              "channelLayout": "stereo",
-              "chapters": [],
-              "embeddedCoverArt": null,
-              "metaTags": {
-                "tagAlbum": "SOT Bk01",
-                "tagArtist": "Terry Goodkind",
-                "tagGenre": "Audiobook Fantasy",
-                "tagTitle": "Wizards First Rule 02",
-                "tagTrack": "02/20",
-                "tagAlbumArtist": "Terry Goodkind",
-                "tagComposer": "Terry Goodkind"
-              },
-              "mimeType": "audio/mpeg"
-            }
-          ],
-          "chapters": [
-            {
-              "id": 0,
-              "start": 0,
-              "end": 6004.6675,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
-            },
-            {
-              "id": 1,
-              "start": 6004.6675,
-              "end": 12000.946,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
-            }
-          ],
-          "duration": 33854.905,
-          "size": 268824228,
-          "tracks": [
-            {
-              "index": 1,
-              "startOffset": 0,
-              "duration": 6004.6675,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "mimeType": "audio/mpeg",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "size": 48037888,
-                "mtimeMs": 1632223180278,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              }
-            },
-            {
-              "index": 2,
-              "startOffset": 6004.6675,
-              "duration": 5996.2785,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "mimeType": "audio/mpeg",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
-                "size": 47972352,
-                "mtimeMs": 1632223180281,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              }
-            }
-          ],
-          "missingParts": [],
-          "ebookFile": null
-        },
-        "libraryFiles": [
-          {
-            "ino": "649644248522215260",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "size": 48037888,
-              "mtimeMs": 1632223180278,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621052494,
-            "updatedAt": 1650621052494,
-            "fileType": "audio"
-          },
-          {
-            "ino": "649644248522215261",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "size": 47972352,
-              "mtimeMs": 1632223180281,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621052494,
-            "updatedAt": 1650621052494,
-            "fileType": "audio"
-          },
-          {
-            "ino": "649644248522215267",
-            "metadata": {
-              "filename": "cover.jpg",
-              "ext": ".jpg",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-              "relPath": "cover.jpg",
-              "size": 325531,
-              "mtimeMs": 1638754803540,
-              "ctimeMs": 1645978261003,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621052495,
-            "updatedAt": 1650621052495,
-            "fileType": "image"
-          }
-        ],
-        "size": 268990279
-      }
-    }
-  ],
-  "lastUpdate": 1669623431313,
-  "createdAt": 1669623431313
-}
-```
-
-This endpoint adds an item to a playlist and returns the updated playlist.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/playlists/<ID>/item`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the playlist.
-
-### Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`libraryItemId` | String | **Required** | The ID of the library item the playlist item is for.
-`episodeId` | String or null | `null` | The ID of the podcast episode the playlist item is for.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Playlist Expanded](#playlist-expanded)
-400 | Bad Request | No library item with the provided ID exists, the library item is in a different library from the playlist, the library item is already in the playlist, the library item is not a podcast and an `episodeId` was provided, the library item is a podcast and an `episodeId` was not provided, or no podcast episode with the provided ID exists in the library item. |
-403 | Forbidden | The playlist does not belong to the authenticated user. |
-404 | Not Found | No playlist with the provided ID exists. |
-
-
-## Remove an Item From a Playlist
-
-```shell
-curl -X DELETE "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu/item/li_8gch9ve09orgn4fdz8" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "pl_qbwet64998s5ra6dcu",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "The Best Books",
-  "description": null,
-  "coverPath": null,
-  "items": [],
-  "lastUpdate": 1669623431313,
-  "createdAt": 1669623431313
-}
-```
-
-This endpoint removes an item from a playlist and returns the updated playlist. Then, if the playlist is empty, it will be deleted.
-
-### HTTP Request
-
-* `DELETE http://abs.example.com/api/playlists/<ID>/item/<LibraryItemID>`
-* `DELETE http://abs.example.com/api/playlists/<ID>/item/<LibraryItemID>/<EpisodeID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the playlist.
-LibraryItemID | The ID of the library item the playlist item to remove is for.
-EpisodeID | The ID of the podcast episode the playlist item to remove is for.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Playlist Expanded](#playlist-expanded)
-403 | Forbidden | The playlist does not belong to the authenticated user. |
-404 | Not Found | No playlist with the provided ID exists, or the playlist does not contain the provided item. |
-
-
-## Batch Add Items to a Playlist
-
-```shell
-curl -X POST "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu/batch/add" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"items": [{"libraryItemId": "li_8gch9ve09orgn4fdz8"}]}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "pl_qbwet64998s5ra6dcu",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "The Best Books",
-  "description": null,
-  "coverPath": null,
-  "items": [
-    {
-      "libraryItemId": "li_8gch9ve09orgn4fdz8",
-      "episodeId": null,
-      "libraryItem": {
-        "id": "li_8gch9ve09orgn4fdz8",
-        "ino": "649641337522215266",
-        "libraryId": "lib_c1u6t4p45c35rf0nzd",
-        "folderId": "fol_bev1zuxhb0j0s1wehr",
-        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
-        "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
-        "isFile": false,
-        "mtimeMs": 1650621074299,
-        "ctimeMs": 1650621074299,
-        "birthtimeMs": 0,
-        "addedAt": 1650621073750,
-        "updatedAt": 1650621110769,
-        "lastScan": 1651830827825,
-        "scanVersion": "2.0.21",
-        "isMissing": false,
-        "isInvalid": false,
-        "mediaType": "book",
-        "media": {
-          "libraryItemId": "li_8gch9ve09orgn4fdz8",
-          "metadata": {
-            "title": "Wizards First Rule",
-            "titleIgnorePrefix": "Wizards First Rule",
-            "subtitle": null,
-            "authors": [
-              {
-                "id": "aut_z3leimgybl7uf3y4ab",
-                "name": "Terry Goodkind"
-              }
-            ],
-            "narrators": [
-              "Sam Tsoutsouvas"
-            ],
-            "series": [
-              {
-                "id": "ser_cabkj4jeu8be3rap4g",
-                "name": "Sword of Truth",
-                "sequence": "1"
-              }
-            ],
-            "genres": [
-              "Fantasy"
-            ],
-            "publishedYear": "2008",
-            "publishedDate": null,
-            "publisher": "Brilliance Audio",
-            "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-            "isbn": null,
-            "asin": "B002V0QK4C",
-            "language": null,
-            "explicit": false,
-            "authorName": "Terry Goodkind",
-            "authorNameLF": "Goodkind, Terry",
-            "narratorName": "Sam Tsoutsouvas",
-            "seriesName": "Sword of Truth"
-          },
-          "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-          "tags": [
-            "Favorite"
-          ],
-          "audioFiles": [
-            {
-              "index": 1,
-              "ino": "649644248522215260",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "size": 48037888,
-                "mtimeMs": 1632223180278,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              },
-              "addedAt": 1650621074131,
-              "updatedAt": 1651830828023,
-              "trackNumFromMeta": 1,
-              "discNumFromMeta": null,
-              "trackNumFromFilename": 1,
-              "discNumFromFilename": null,
-              "manuallyVerified": false,
-              "invalid": false,
-              "exclude": false,
-              "error": null,
-              "format": "MP2/3 (MPEG audio layer 2/3)",
-              "duration": 6004.6675,
-              "bitRate": 64000,
-              "language": null,
-              "codec": "mp3",
-              "timeBase": "1/14112000",
-              "channels": 2,
-              "channelLayout": "stereo",
-              "chapters": [],
-              "embeddedCoverArt": null,
-              "metaTags": {
-                "tagAlbum": "SOT Bk01",
-                "tagArtist": "Terry Goodkind",
-                "tagGenre": "Audiobook Fantasy",
-                "tagTitle": "Wizards First Rule 01",
-                "tagTrack": "01/20",
-                "tagAlbumArtist": "Terry Goodkind",
-                "tagComposer": "Terry Goodkind"
-              },
-              "mimeType": "audio/mpeg"
-            },
-            {
-              "index": 2,
-              "ino": "649644248522215261",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "size": 47972352,
-                "mtimeMs": 1632223180281,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              },
-              "addedAt": 1650621074130,
-              "updatedAt": 1651830828023,
-              "trackNumFromMeta": 2,
-              "discNumFromMeta": null,
-              "trackNumFromFilename": 1,
-              "discNumFromFilename": null,
-              "manuallyVerified": false,
-              "invalid": false,
-              "exclude": false,
-              "error": null,
-              "format": "MP2/3 (MPEG audio layer 2/3)",
-              "duration": 5996.2785,
-              "bitRate": 64000,
-              "language": null,
-              "codec": "mp3",
-              "timeBase": "1/14112000",
-              "channels": 2,
-              "channelLayout": "stereo",
-              "chapters": [],
-              "embeddedCoverArt": null,
-              "metaTags": {
-                "tagAlbum": "SOT Bk01",
-                "tagArtist": "Terry Goodkind",
-                "tagGenre": "Audiobook Fantasy",
-                "tagTitle": "Wizards First Rule 02",
-                "tagTrack": "02/20",
-                "tagAlbumArtist": "Terry Goodkind",
-                "tagComposer": "Terry Goodkind"
-              },
-              "mimeType": "audio/mpeg"
-            }
-          ],
-          "chapters": [
-            {
-              "id": 0,
-              "start": 0,
-              "end": 6004.6675,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
-            },
-            {
-              "id": 1,
-              "start": 6004.6675,
-              "end": 12000.946,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
-            }
-          ],
-          "duration": 33854.905,
-          "size": 268824228,
-          "tracks": [
-            {
-              "index": 1,
-              "startOffset": 0,
-              "duration": 6004.6675,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "mimeType": "audio/mpeg",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "size": 48037888,
-                "mtimeMs": 1632223180278,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              }
-            },
-            {
-              "index": 2,
-              "startOffset": 6004.6675,
-              "duration": 5996.2785,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "mimeType": "audio/mpeg",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
-                "size": 47972352,
-                "mtimeMs": 1632223180281,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              }
-            }
-          ],
-          "missingParts": [],
-          "ebookFile": null
-        },
-        "libraryFiles": [
-          {
-            "ino": "649644248522215260",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "size": 48037888,
-              "mtimeMs": 1632223180278,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621052494,
-            "updatedAt": 1650621052494,
-            "fileType": "audio"
-          },
-          {
-            "ino": "649644248522215261",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "size": 47972352,
-              "mtimeMs": 1632223180281,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621052494,
-            "updatedAt": 1650621052494,
-            "fileType": "audio"
-          },
-          {
-            "ino": "649644248522215267",
-            "metadata": {
-              "filename": "cover.jpg",
-              "ext": ".jpg",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-              "relPath": "cover.jpg",
-              "size": 325531,
-              "mtimeMs": 1638754803540,
-              "ctimeMs": 1645978261003,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621052495,
-            "updatedAt": 1650621052495,
-            "fileType": "image"
-          }
-        ],
-        "size": 268990279
-      }
-    }
-  ],
-  "lastUpdate": 1669623431313,
-  "createdAt": 1669623431313
-}
-```
-
-This endpoint batch adds items to a playlist and returns the updated playlist.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/playlists/<ID>/batch/add`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the playlist.
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`items` | Array of [Playlist Item](#playlist-item) | The items to add to the playlist.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Playlist Expanded](#playlist-expanded)
-400 | Bad Request | One or more of the provided items does not have a `libraryItemId`. |
-403 | Forbidden | The playlist does not belong to the authenticated user. |
-404 | Not Found | No playlist with the provided ID exists. |
-500 | Internal Server Error | The provided `items` array was empty or did not exist. |
-
-
-## Batch Remove Items From a Playlist
-
-```shell
-curl -X POST "https://abs.example.com/api/playlists/pl_qbwet64998s5ra6dcu/batch/remove" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"items": [{"libraryItemId": "li_8gch9ve09orgn4fdz8"}]}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "pl_qbwet64998s5ra6dcu",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "The Best Books",
-  "description": null,
-  "coverPath": null,
-  "items": [],
-  "lastUpdate": 1669623431313,
-  "createdAt": 1669623431313
-}
-```
-
-This endpoint batch removes items from a playlist and returns the updated playlist. Then, if the playlist is empty, it will be deleted.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/playlists/<ID>/batch/remove`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the playlist.
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`items` | Array of [Playlist Item](#playlist-item) | The items to remove from the playlist.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Playlist Expanded](#playlist-expanded)
-400 | Bad Request | One or more of the provided items does not have a `libraryItemId`. |
-403 | Forbidden | The playlist does not belong to the authenticated user. |
-404 | Not Found | No playlist with the provided ID exists. |
-500 | Internal Server Error | The provided `items` array was empty or did not exist. |
-
-
-## Create a Playlist From a Collection
-
-```shell
-curl -X POST "https://abs.example.com/api/playlists/collection/col_fpfstanv6gd7tq2qz7" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "pl_qbwet64998s5ra6dcu",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "Favorites",
-  "description": null,
-  "coverPath": null,
-  "items": [
-    {
-      "libraryItemId": "li_8gch9ve09orgn4fdz8",
-      "episodeId": null,
-      "libraryItem": {
-        "id": "li_8gch9ve09orgn4fdz8",
-        "ino": "649641337522215266",
-        "libraryId": "lib_c1u6t4p45c35rf0nzd",
-        "folderId": "fol_bev1zuxhb0j0s1wehr",
-        "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule",
-        "relPath": "Terry Goodkind/Sword of Truth/Wizards First Rule",
-        "isFile": false,
-        "mtimeMs": 1650621074299,
-        "ctimeMs": 1650621074299,
-        "birthtimeMs": 0,
-        "addedAt": 1650621073750,
-        "updatedAt": 1650621110769,
-        "lastScan": 1651830827825,
-        "scanVersion": "2.0.21",
-        "isMissing": false,
-        "isInvalid": false,
-        "mediaType": "book",
-        "media": {
-          "libraryItemId": "li_8gch9ve09orgn4fdz8",
-          "metadata": {
-            "title": "Wizards First Rule",
-            "titleIgnorePrefix": "Wizards First Rule",
-            "subtitle": null,
-            "authors": [
-              {
-                "id": "aut_z3leimgybl7uf3y4ab",
-                "name": "Terry Goodkind"
-              }
-            ],
-            "narrators": [
-              "Sam Tsoutsouvas"
-            ],
-            "series": [
-              {
-                "id": "ser_cabkj4jeu8be3rap4g",
-                "name": "Sword of Truth",
-                "sequence": "1"
-              }
-            ],
-            "genres": [
-              "Fantasy"
-            ],
-            "publishedYear": "2008",
-            "publishedDate": null,
-            "publisher": "Brilliance Audio",
-            "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-            "isbn": null,
-            "asin": "B002V0QK4C",
-            "language": null,
-            "explicit": false,
-            "authorName": "Terry Goodkind",
-            "authorNameLF": "Goodkind, Terry",
-            "narratorName": "Sam Tsoutsouvas",
-            "seriesName": "Sword of Truth"
-          },
-          "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-          "tags": [
-            "Favorite"
-          ],
-          "audioFiles": [
-            {
-              "index": 1,
-              "ino": "649644248522215260",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "size": 48037888,
-                "mtimeMs": 1632223180278,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              },
-              "addedAt": 1650621074131,
-              "updatedAt": 1651830828023,
-              "trackNumFromMeta": 1,
-              "discNumFromMeta": null,
-              "trackNumFromFilename": 1,
-              "discNumFromFilename": null,
-              "manuallyVerified": false,
-              "invalid": false,
-              "exclude": false,
-              "error": null,
-              "format": "MP2/3 (MPEG audio layer 2/3)",
-              "duration": 6004.6675,
-              "bitRate": 64000,
-              "language": null,
-              "codec": "mp3",
-              "timeBase": "1/14112000",
-              "channels": 2,
-              "channelLayout": "stereo",
-              "chapters": [],
-              "embeddedCoverArt": null,
-              "metaTags": {
-                "tagAlbum": "SOT Bk01",
-                "tagArtist": "Terry Goodkind",
-                "tagGenre": "Audiobook Fantasy",
-                "tagTitle": "Wizards First Rule 01",
-                "tagTrack": "01/20",
-                "tagAlbumArtist": "Terry Goodkind",
-                "tagComposer": "Terry Goodkind"
-              },
-              "mimeType": "audio/mpeg"
-            },
-            {
-              "index": 2,
-              "ino": "649644248522215261",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "size": 47972352,
-                "mtimeMs": 1632223180281,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              },
-              "addedAt": 1650621074130,
-              "updatedAt": 1651830828023,
-              "trackNumFromMeta": 2,
-              "discNumFromMeta": null,
-              "trackNumFromFilename": 1,
-              "discNumFromFilename": null,
-              "manuallyVerified": false,
-              "invalid": false,
-              "exclude": false,
-              "error": null,
-              "format": "MP2/3 (MPEG audio layer 2/3)",
-              "duration": 5996.2785,
-              "bitRate": 64000,
-              "language": null,
-              "codec": "mp3",
-              "timeBase": "1/14112000",
-              "channels": 2,
-              "channelLayout": "stereo",
-              "chapters": [],
-              "embeddedCoverArt": null,
-              "metaTags": {
-                "tagAlbum": "SOT Bk01",
-                "tagArtist": "Terry Goodkind",
-                "tagGenre": "Audiobook Fantasy",
-                "tagTitle": "Wizards First Rule 02",
-                "tagTrack": "02/20",
-                "tagAlbumArtist": "Terry Goodkind",
-                "tagComposer": "Terry Goodkind"
-              },
-              "mimeType": "audio/mpeg"
-            }
-          ],
-          "chapters": [
-            {
-              "id": 0,
-              "start": 0,
-              "end": 6004.6675,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
-            },
-            {
-              "id": 1,
-              "start": 6004.6675,
-              "end": 12000.946,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02"
-            }
-          ],
-          "duration": 33854.905,
-          "size": 268824228,
-          "tracks": [
-            {
-              "index": 1,
-              "startOffset": 0,
-              "duration": 6004.6675,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "mimeType": "audio/mpeg",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-                "size": 48037888,
-                "mtimeMs": 1632223180278,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              }
-            },
-            {
-              "index": 2,
-              "startOffset": 6004.6675,
-              "duration": 5996.2785,
-              "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "mimeType": "audio/mpeg",
-              "metadata": {
-                "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "ext": ".mp3",
-                "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-                "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 03.mp3",
-                "size": 47972352,
-                "mtimeMs": 1632223180281,
-                "ctimeMs": 1645978261001,
-                "birthtimeMs": 0
-              }
-            }
-          ],
-          "missingParts": [],
-          "ebookFile": null
-        },
-        "libraryFiles": [
-          {
-            "ino": "649644248522215260",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-              "size": 48037888,
-              "mtimeMs": 1632223180278,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621052494,
-            "updatedAt": 1650621052494,
-            "fileType": "audio"
-          },
-          {
-            "ino": "649644248522215261",
-            "metadata": {
-              "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "ext": ".mp3",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 02.mp3",
-              "size": 47972352,
-              "mtimeMs": 1632223180281,
-              "ctimeMs": 1645978261001,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621052494,
-            "updatedAt": 1650621052494,
-            "fileType": "audio"
-          },
-          {
-            "ino": "649644248522215267",
-            "metadata": {
-              "filename": "cover.jpg",
-              "ext": ".jpg",
-              "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-              "relPath": "cover.jpg",
-              "size": 325531,
-              "mtimeMs": 1638754803540,
-              "ctimeMs": 1645978261003,
-              "birthtimeMs": 0
-            },
-            "addedAt": 1650621052495,
-            "updatedAt": 1650621052495,
-            "fileType": "image"
-          }
-        ],
-        "size": 268990279
-      }
-    }
-  ],
-  "lastUpdate": 1669623431313,
-  "createdAt": 1669623431313
-}
-```
-
-This endpoint creates a playlist from a collection. The newly created playlist is returned.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/playlists/collection/<CollectionID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-CollectionID | The ID of the collection.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Playlist Expanded](#playlist-expanded)
-400 | Bad Request | The user cannot access any books contained in the collection. |
-404 | Not Found | No collection with the given ID exists. |

--- a/source/includes/_podcasts.md
+++ b/source/includes/_podcasts.md
@@ -1,5 +1,103 @@
 # Podcasts
 
+## Check for New Podcast Episodes
+
+```shell
+curl "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/checknew" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "episodes": [
+    {
+      "title": "1 - Pilot",
+      "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
+      "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
+      "descriptionPlain": "\n        Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.\n\nWeather: \"These and More Than These\" by Joseph Fink\n\nMusic: Disparition, disparition.info\n\nLogo: Rob Wilson, silastom.com\n\nProduced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.\n      ",
+      "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
+      "episodeType": "full",
+      "season": "",
+      "episode": "",
+      "author": "",
+      "duration": "21:02",
+      "explicit": "",
+      "publishedAt": 1339761600000,
+      "enclosure": {
+        "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
+        "type": "audio/mpeg",
+        "length": "20588611"
+      }
+    }
+  ]
+}
+```
+
+This endpoint checks for new episodes for a podcast, which the server downloads, and returns the podcast episode feed data.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/podcasts/<ID>/checknew`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the podcast library item.
+
+### Optional Query Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`limit` | Integer | `3` | The maximum number of new episodes to download. If `0`, all episodes will be downloaded.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+403 | Forbidden | The user is not allowed to access the library item. An admin user is required to check for new podcast episodes. |
+404 | Not Found | No library item with the given ID exists. |
+500 | Internal Server Error | The library item is not a podcast. The podcast must have an RSS feed URL. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`episodes` | Array of [Podcast Feed Episode](#podcast-feed-episode) | The new podcast episodes that will be downloaded.
+
+
+## Clear a Podcast's Episode Download Queue
+
+```shell
+curl "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/clear-queue" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint clears a podcast's episode download queue.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/podcasts/<ID>/clear-queue`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the podcast library item.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | The user is not allowed to access the library item. An admin user is required to clear a podcast's episode download queue.
+404 | Not Found | No library item with the given ID exists.
+500 | Internal Server Error | The library item is not a podcast.
+
+
 ## Create a Podcast
 
 ```shell
@@ -150,87 +248,221 @@ Status | Meaning | Description | Schema
 404 | Not Found | The given library ID or folder ID does not exist. |
 
 
-## Get a Podcast's Feed
+## Delete a Podcast Episode
 
 ```shell
-curl -X POST "https://abs.example.com/api/podcasts/feed" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"rssFeed": "http://feeds.nightvalepresents.com/welcometonightvalepodcast"}'
+curl -X DELETE "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/episode/ep_lh6ko39pumnrma3dhv?hard=1" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
 > The above command returns JSON structured like this:
 
 ```json
 {
-  "podcast": {
+  "id": "li_bufnnmp4y5o2gbbxfm",
+  "ino": "652",
+  "libraryId": "lib_p9wkw2i85qy9oltijt",
+  "folderId": "fol_crxarzs17jtw5k7ie9",
+  "path": "/podcasts/Welcome to Night Vale",
+  "relPath": "Welcome to Night Vale",
+  "isFile": false,
+  "mtimeMs": 1668124892694,
+  "ctimeMs": 1668124892694,
+  "birthtimeMs": 1667326662083,
+  "addedAt": 1667326662087,
+  "updatedAt": 1668853355724,
+  "lastScan": 1668234374487,
+  "scanVersion": "2.2.2",
+  "isMissing": false,
+  "isInvalid": false,
+  "mediaType": "podcast",
+  "media": {
+    "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
     "metadata": {
-      "image": "https://f.prxu.org/126/images/1f749c5d-c83a-4db9-8112-a3245da49c54/nightvalelogo-web4.jpg",
-      "categories": [
-        "Fiction:Science Fiction"
+      "title": "Welcome to Night Vale",
+      "author": "Night Vale Presents",
+      "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+      "releaseDate": "2022-10-20T19:00:00Z",
+      "genres": [
+        "Science Fiction",
+        "Podcasts",
+        "Fiction"
       ],
       "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
-      "description": "\n      <p>Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.</p>\n    ",
-      "descriptionPlain": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-      "title": "Welcome to Night Vale",
-      "language": "en",
-      "explicit": "false",
-      "author": "Night Vale Presents",
-      "pubDate": "Thu, 17 Nov 2022 16:04:42 -0000",
-      "link": "http://welcometonightvale.com"
+      "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
+      "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
+      "itunesId": 536258179,
+      "itunesArtistId": 718704794,
+      "explicit": false,
+      "language": null,
+      "type": "episodic"
     },
-    "episodes": [
-      ...,
-      {
-        "title": "1 - Pilot",
-        "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
-        "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
-        "descriptionPlain": "\n        Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.\n\nWeather: \"These and More Than These\" by Joseph Fink\n\nMusic: Disparition, disparition.info\n\nLogo: Rob Wilson, silastom.com\n\nProduced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.\n      ",
-        "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
-        "episodeType": "full",
-        "season": "",
-        "episode": "",
-        "author": "",
-        "duration": "21:02",
-        "explicit": "",
-        "publishedAt": 1339761600000,
-        "enclosure": {
-          "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
-          "type": "audio/mpeg",
-          "length": "20588611"
-        }
+    "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg",
+    "tags": [],
+    "episodes": [],
+    "autoDownloadEpisodes": false,
+    "autoDownloadSchedule": "0 0 * * 1",
+    "lastEpisodeCheck": 1667326662087,
+    "maxEpisodesToKeep": 0,
+    "maxNewEpisodesToDownload": 3
+  },
+  "libraryFiles": [
+    {
+      "ino": "10113",
+      "metadata": {
+        "filename": "cover.jpg",
+        "ext": ".jpg",
+        "path": "/podcasts/Welcome to Night Vale/cover.jpg",
+        "relPath": "cover.jpg",
+        "size": 52993,
+        "mtimeMs": 1667326662178,
+        "ctimeMs": 1667326662184,
+        "birthtimeMs": 1667326662090
       },
-      ...
-    ]
-  }
+      "addedAt": 1667327311529,
+      "updatedAt": 1667327311529,
+      "fileType": "image"
+    }
+  ]
 }
 ```
 
-This endpoint takes a podcast's RSS feed and returns the feed's data.
+This endpoint deletes a podcast episode from the database. If providing the `hard` parameter, the file will be deleted as well.
 
 ### HTTP Request
 
-`POST http://abs.example.com/api/podcasts/feed`
+`DELETE http://abs.example.com/api/podcasts/<ID>/episode/<EpisodeID>`
 
-### Parameters
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the podcast library item.
+EpisodeID | The ID of the podcast episode.
+
+### Query Parameters
 
 Parameter | Type | Description
 --------- | ---- | -----------
-`rssFeed` | String | A URL of an RSS feed for the podcast.
+`hard` | Binary | Whether to delete the podcast episode files from the server. `0` for false, `1` for true.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | [Library Item](#library-item)
+403 | Forbidden | The user is not allowed to access the library item. A user with delete permissions is required to delete podcast episodes. |
+404 | Not Found | No library item with the given ID exists, or no episode with the given ID exists. |
+500 | Internal Server Error | The library item is not a podcast. |
+
+## Download Podcast Episodes
+
+```shell
+curl -X POST "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/download-episodes" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '[{"episodeType": "full", "title": "2 - Glow Cloud", "subtitle": "A mysterious, glowing cloud makes its way across Night Vale. Plus, new Boy Scouts hierarchy, community events calendar, and a PTA bake sale for a great cause! Weather: \"The Bus is Late\" by Satellite High, satellite-high.com Music: Disparition,...", "description": "\n        <p>A mysterious, glowing cloud makes its way across Night Vale. Plus, new Boy Scouts hierarchy, community events calendar, and a PTA bake sale for a great cause!</p>\n\n<p>Weather: \"The Bus is Late\" by Satellite High, <a target=\"_blank\">satellite-high.com</a></p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ", "enclosure": {"url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/cb1dd91f-5d8d-42e9-ba22-14ff335d2cbb/2_Glow_Cloud.mp3", "type": "audio/mpeg", "length": "19937018"}, "pubDate": "Sun, 01 Jul 2012 12:00:00 -0000", "publishedAt": 1341144000000}]'
+```
+
+This endpoint downloads new episodes for a podcast to the server.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/podcasts/<ID>/download-episodes`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the podcast library item.
+
+### Parameters
+
+Provided an array of objects with the following parameters for each episode to download.
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`season` | String | `''` | The season of the podcast episode, if known.
+`episode` | String | `''` | The episode of the season of the podcast, if known.
+`episodeType` | String | `''` | The type of episode that the podcast episode is.
+`title` | String | `''` | The title of the podcast episode.
+`subtitle` | String | `''` | The subtitle of the podcast episode.
+`description` | String | `''` | A HTML encoded, description of the podcast episode.
+`enclosure` | [Podcast Episode Enclosure](#podcast-episode-enclosure) Object or null | `null` | The podcast episode download information.
+`pubDate` | String | `''` | When the podcast episode was published.
+`publishedAt` | Integer | `0` | The time (in ms since POSIX epoch) when the podcast episode was published.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+400 | Bad Request | The provided array must have a non-zero length.
+403 | Forbidden | The user is not allowed to access the library item. An admin user is required to download new podcast episodes.
+404 | Not Found | No library item with the given ID exists.
+500 | Internal Server Error | The library item is not a podcast.
+
+
+## Get Podcast Episode Downloads
+
+```shell
+curl "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/downloads" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "downloads": [
+    {
+      "id": "epdl_pgv4d47j6dtqpk4r0v",
+      "episodeDisplayTitle": "2 - Glow Cloud",
+      "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/cb1dd91f-5d8d-42e9-ba22-14ff335d2cbb/2_Glow_Cloud.mp3",
+      "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+      "libraryId": "lib_p9wkw2i85qy9oltijt",
+      "isFinished": false,
+      "failed": false,
+      "startedAt": null,
+      "createdAt": 1668122813409,
+      "finishedAt": null,
+      "podcastTitle": "Welcome to Night Vale",
+      "podcastExplicit": false,
+      "season": "",
+      "episode": "",
+      "episodeType": "full",
+      "publishedAt": 1341144000000
+    }
+  ]
+}
+```
+
+This endpoint retrieves the episodes currently in the download queue for the podcast.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/podcasts/<ID>/downloads`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the podcast library item.
 
 ### Response
 
 Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
 200 | OK | Success | See below.
-400 | Bad Request | The `rssFeed` parameter is required. |
-404 | Not Found | The podcast RSS feed request failed or had invalid response data. |
+403 | Forbidden | The user is not allowed to access the library item. |
+404 | Not Found | No library item with the given ID exists. |
+500 | Internal Server Error | The library item is not a podcast. |
 
 #### Response Schema
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`podcast` | [Podcast Feed](#podcast-feed) Object | The requested podcast feed data.
+`downloads` | Array of [Podcast Episode Download](#podcast-episode-download) | The episodes currently in the download queue for the podcast.
 
 
 ## Get Podcast Feeds From OPML
@@ -299,342 +531,6 @@ Or if there is an error (i.e. no RSS feeds were in the OPML text):
 Attribute | Type | Description
 --------- | ---- | -----------
 `error` | String | The error that occurred.
-
-
-## Check for New Podcast Episodes
-
-```shell
-curl "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/checknew" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "episodes": [
-    {
-      "title": "1 - Pilot",
-      "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
-      "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
-      "descriptionPlain": "\n        Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.\n\nWeather: \"These and More Than These\" by Joseph Fink\n\nMusic: Disparition, disparition.info\n\nLogo: Rob Wilson, silastom.com\n\nProduced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.\n      ",
-      "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
-      "episodeType": "full",
-      "season": "",
-      "episode": "",
-      "author": "",
-      "duration": "21:02",
-      "explicit": "",
-      "publishedAt": 1339761600000,
-      "enclosure": {
-        "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
-        "type": "audio/mpeg",
-        "length": "20588611"
-      }
-    }
-  ]
-}
-```
-
-This endpoint checks for new episodes for a podcast, which the server downloads, and returns the podcast episode feed data.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/podcasts/<ID>/checknew`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the podcast library item.
-
-### Optional Query Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`limit` | Integer | `3` | The maximum number of new episodes to download. If `0`, all episodes will be downloaded.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-403 | Forbidden | The user is not allowed to access the library item. An admin user is required to check for new podcast episodes. |
-404 | Not Found | No library item with the given ID exists. |
-500 | Internal Server Error | The library item is not a podcast. The podcast must have an RSS feed URL. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`episodes` | Array of [Podcast Feed Episode](#podcast-feed-episode) | The new podcast episodes that will be downloaded.
-
-
-## Get Podcast Episode Downloads
-
-```shell
-curl "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/downloads" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "downloads": [
-    {
-      "id": "epdl_pgv4d47j6dtqpk4r0v",
-      "episodeDisplayTitle": "2 - Glow Cloud",
-      "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/cb1dd91f-5d8d-42e9-ba22-14ff335d2cbb/2_Glow_Cloud.mp3",
-      "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-      "libraryId": "lib_p9wkw2i85qy9oltijt",
-      "isFinished": false,
-      "failed": false,
-      "startedAt": null,
-      "createdAt": 1668122813409,
-      "finishedAt": null,
-      "podcastTitle": "Welcome to Night Vale",
-      "podcastExplicit": false,
-      "season": "",
-      "episode": "",
-      "episodeType": "full",
-      "publishedAt": 1341144000000
-    }
-  ]
-}
-```
-
-This endpoint retrieves the episodes currently in the download queue for the podcast.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/podcasts/<ID>/downloads`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the podcast library item.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-403 | Forbidden | The user is not allowed to access the library item. |
-404 | Not Found | No library item with the given ID exists. |
-500 | Internal Server Error | The library item is not a podcast. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`downloads` | Array of [Podcast Episode Download](#podcast-episode-download) | The episodes currently in the download queue for the podcast.
-
-
-## Clear a Podcast's Episode Download Queue
-
-```shell
-curl "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/clear-queue" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint clears a podcast's episode download queue.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/podcasts/<ID>/clear-queue`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the podcast library item.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | The user is not allowed to access the library item. An admin user is required to clear a podcast's episode download queue.
-404 | Not Found | No library item with the given ID exists.
-500 | Internal Server Error | The library item is not a podcast.
-
-
-## Search a Podcast's Feed for Episodes
-
-```shell
-curl "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/search-episode?title=Pilot" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "episodes": [
-    {
-      "episode": {
-        "title": "1 - Pilot",
-        "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
-        "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
-        "descriptionPlain": "\n        Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.\n\nWeather: \"These and More Than These\" by Joseph Fink\n\nMusic: Disparition, disparition.info\n\nLogo: Rob Wilson, silastom.com\n\nProduced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.\n      ",
-        "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
-        "episodeType": "full",
-        "season": "",
-        "episode": "",
-        "author": "",
-        "duration": "21:02",
-        "explicit": "",
-        "publishedAt": 1339761600000,
-        "enclosure": {
-          "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
-          "type": "audio/mpeg",
-          "length": "20588611"
-        }
-      },
-      "levenshtein": 4
-    }
-  ]
-}
-```
-
-This endpoint searches a podcast's feed for an episode with the given title.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/podcasts/<ID>/search-episode`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the podcast library item.
-
-### Query Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`title` | String | The podcast episode title to search for.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-403 | Forbidden | The user is not allowed to access the library item. |
-404 | Not Found | No library item with the given ID exists. |
-500 | Internal Server Error | The library item is not a podcast. The podcast must have an RSS feed URL. `title` is a required parameter. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`episodes` | Array of [Podcast Search Episode](#podcast-search-episode) (See Below) | The matching podcast episodes.
-
-#### Podcast Search Episode
-
-Attribute | Type | Description
---------- | ---- | -----------
-`episode` | [Podcast Feed Episode](#podcast-feed-episode) Object | The podcast episode feed data.
-`levenshtein` | Integer | The [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) between the search title and the podcast episode's title.
-
-
-## Download Podcast Episodes
-
-```shell
-curl -X POST "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/download-episodes" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '[{"episodeType": "full", "title": "2 - Glow Cloud", "subtitle": "A mysterious, glowing cloud makes its way across Night Vale. Plus, new Boy Scouts hierarchy, community events calendar, and a PTA bake sale for a great cause! Weather: \"The Bus is Late\" by Satellite High, satellite-high.com Music: Disparition,...", "description": "\n        <p>A mysterious, glowing cloud makes its way across Night Vale. Plus, new Boy Scouts hierarchy, community events calendar, and a PTA bake sale for a great cause!</p>\n\n<p>Weather: \"The Bus is Late\" by Satellite High, <a target=\"_blank\">satellite-high.com</a></p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ", "enclosure": {"url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/cb1dd91f-5d8d-42e9-ba22-14ff335d2cbb/2_Glow_Cloud.mp3", "type": "audio/mpeg", "length": "19937018"}, "pubDate": "Sun, 01 Jul 2012 12:00:00 -0000", "publishedAt": 1341144000000}]'
-```
-
-This endpoint downloads new episodes for a podcast to the server.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/podcasts/<ID>/download-episodes`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the podcast library item.
-
-### Parameters
-
-Provided an array of objects with the following parameters for each episode to download.
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`season` | String | `''` | The season of the podcast episode, if known.
-`episode` | String | `''` | The episode of the season of the podcast, if known.
-`episodeType` | String | `''` | The type of episode that the podcast episode is.
-`title` | String | `''` | The title of the podcast episode.
-`subtitle` | String | `''` | The subtitle of the podcast episode.
-`description` | String | `''` | A HTML encoded, description of the podcast episode.
-`enclosure` | [Podcast Episode Enclosure](#podcast-episode-enclosure) Object or null | `null` | The podcast episode download information.
-`pubDate` | String | `''` | When the podcast episode was published.
-`publishedAt` | Integer | `0` | The time (in ms since POSIX epoch) when the podcast episode was published.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-400 | Bad Request | The provided array must have a non-zero length.
-403 | Forbidden | The user is not allowed to access the library item. An admin user is required to download new podcast episodes.
-404 | Not Found | No library item with the given ID exists.
-500 | Internal Server Error | The library item is not a podcast.
-
-
-## Match a Podcast's Episodes
-
-```shell
-curl -X POST "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/match-episodes" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"provider": "openlibrary"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "numEpisodesUpdated": 1
-}
-```
-
-This endpoint matches the podcast's episodes using quick match. Quick match populates empty details. Does not overwrite details unless the "Prefer matched metadata" server setting is enabled or the `override` query parameter is `1`.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/podcasts/<ID>/match-episodes`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the podcast library item.
-
-### Query Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`override` | Binary | `0` | Whether the podcast's episodes' details will be overridden. `0` for false, `1` for true.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-403 | Forbidden | An admin user is required to match a podcast's episodes. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`numEpisodesUpdated` | Integer | The number of podcast episodes that were updated.
 
 
 ## Get a Podcast Episode
@@ -733,6 +629,217 @@ Status | Meaning | Description | Schema
 403 | Forbidden | The user is not allowed to access the library item. |
 404 | Not Found | No podcast episode with the given ID exists. |
 500 | Internal Server Error | The library item is not a podcast. |
+
+
+## Get a Podcast's Feed
+
+```shell
+curl -X POST "https://abs.example.com/api/podcasts/feed" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"rssFeed": "http://feeds.nightvalepresents.com/welcometonightvalepodcast"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "podcast": {
+    "metadata": {
+      "image": "https://f.prxu.org/126/images/1f749c5d-c83a-4db9-8112-a3245da49c54/nightvalelogo-web4.jpg",
+      "categories": [
+        "Fiction:Science Fiction"
+      ],
+      "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
+      "description": "\n      <p>Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.</p>\n    ",
+      "descriptionPlain": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+      "title": "Welcome to Night Vale",
+      "language": "en",
+      "explicit": "false",
+      "author": "Night Vale Presents",
+      "pubDate": "Thu, 17 Nov 2022 16:04:42 -0000",
+      "link": "http://welcometonightvale.com"
+    },
+    "episodes": [
+      ...,
+      {
+        "title": "1 - Pilot",
+        "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
+        "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
+        "descriptionPlain": "\n        Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.\n\nWeather: \"These and More Than These\" by Joseph Fink\n\nMusic: Disparition, disparition.info\n\nLogo: Rob Wilson, silastom.com\n\nProduced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.\n      ",
+        "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
+        "episodeType": "full",
+        "season": "",
+        "episode": "",
+        "author": "",
+        "duration": "21:02",
+        "explicit": "",
+        "publishedAt": 1339761600000,
+        "enclosure": {
+          "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
+          "type": "audio/mpeg",
+          "length": "20588611"
+        }
+      },
+      ...
+    ]
+  }
+}
+```
+
+This endpoint takes a podcast's RSS feed and returns the feed's data.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/podcasts/feed`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`rssFeed` | String | A URL of an RSS feed for the podcast.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+400 | Bad Request | The `rssFeed` parameter is required. |
+404 | Not Found | The podcast RSS feed request failed or had invalid response data. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`podcast` | [Podcast Feed](#podcast-feed) Object | The requested podcast feed data.
+
+
+## Match a Podcast's Episodes
+
+```shell
+curl -X POST "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/match-episodes" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"provider": "openlibrary"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "numEpisodesUpdated": 1
+}
+```
+
+This endpoint matches the podcast's episodes using quick match. Quick match populates empty details. Does not overwrite details unless the "Prefer matched metadata" server setting is enabled or the `override` query parameter is `1`.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/podcasts/<ID>/match-episodes`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the podcast library item.
+
+### Query Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`override` | Binary | `0` | Whether the podcast's episodes' details will be overridden. `0` for false, `1` for true.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+403 | Forbidden | An admin user is required to match a podcast's episodes. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`numEpisodesUpdated` | Integer | The number of podcast episodes that were updated.
+
+
+## Search a Podcast's Feed for Episodes
+
+```shell
+curl "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/search-episode?title=Pilot" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "episodes": [
+    {
+      "episode": {
+        "title": "1 - Pilot",
+        "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
+        "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
+        "descriptionPlain": "\n        Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.\n\nWeather: \"These and More Than These\" by Joseph Fink\n\nMusic: Disparition, disparition.info\n\nLogo: Rob Wilson, silastom.com\n\nProduced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.\n      ",
+        "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
+        "episodeType": "full",
+        "season": "",
+        "episode": "",
+        "author": "",
+        "duration": "21:02",
+        "explicit": "",
+        "publishedAt": 1339761600000,
+        "enclosure": {
+          "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
+          "type": "audio/mpeg",
+          "length": "20588611"
+        }
+      },
+      "levenshtein": 4
+    }
+  ]
+}
+```
+
+This endpoint searches a podcast's feed for an episode with the given title.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/podcasts/<ID>/search-episode`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the podcast library item.
+
+### Query Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`title` | String | The podcast episode title to search for.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+403 | Forbidden | The user is not allowed to access the library item. |
+404 | Not Found | No library item with the given ID exists. |
+500 | Internal Server Error | The library item is not a podcast. The podcast must have an RSS feed URL. `title` is a required parameter. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`episodes` | Array of [Podcast Search Episode](#podcast-search-episode) (See Below) | The matching podcast episodes.
+
+#### Podcast Search Episode
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`episode` | [Podcast Feed Episode](#podcast-feed-episode) Object | The podcast episode feed data.
+`levenshtein` | Integer | The [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) between the search title and the podcast episode's title.
 
 
 ## Update a Podcast Episode
@@ -954,113 +1061,5 @@ Status | Meaning | Description | Schema
 ------ | ------- | ----------- | ------
 200 | OK | Success | [Library Item Expanded](#library-item-expanded)
 403 | Forbidden | The user is not allowed to access the library item. A user with update permissions is required to update podcast episodes. |
-404 | Not Found | No library item with the given ID exists, or no episode with the given ID exists. |
-500 | Internal Server Error | The library item is not a podcast. |
-
-
-## Delete a Podcast Episode
-
-```shell
-curl -X DELETE "https://abs.example.com/api/podcasts/li_bufnnmp4y5o2gbbxfm/episode/ep_lh6ko39pumnrma3dhv?hard=1" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "li_bufnnmp4y5o2gbbxfm",
-  "ino": "652",
-  "libraryId": "lib_p9wkw2i85qy9oltijt",
-  "folderId": "fol_crxarzs17jtw5k7ie9",
-  "path": "/podcasts/Welcome to Night Vale",
-  "relPath": "Welcome to Night Vale",
-  "isFile": false,
-  "mtimeMs": 1668124892694,
-  "ctimeMs": 1668124892694,
-  "birthtimeMs": 1667326662083,
-  "addedAt": 1667326662087,
-  "updatedAt": 1668853355724,
-  "lastScan": 1668234374487,
-  "scanVersion": "2.2.2",
-  "isMissing": false,
-  "isInvalid": false,
-  "mediaType": "podcast",
-  "media": {
-    "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-    "metadata": {
-      "title": "Welcome to Night Vale",
-      "author": "Night Vale Presents",
-      "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-      "releaseDate": "2022-10-20T19:00:00Z",
-      "genres": [
-        "Science Fiction",
-        "Podcasts",
-        "Fiction"
-      ],
-      "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
-      "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
-      "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
-      "itunesId": 536258179,
-      "itunesArtistId": 718704794,
-      "explicit": false,
-      "language": null,
-      "type": "episodic"
-    },
-    "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg",
-    "tags": [],
-    "episodes": [],
-    "autoDownloadEpisodes": false,
-    "autoDownloadSchedule": "0 0 * * 1",
-    "lastEpisodeCheck": 1667326662087,
-    "maxEpisodesToKeep": 0,
-    "maxNewEpisodesToDownload": 3
-  },
-  "libraryFiles": [
-    {
-      "ino": "10113",
-      "metadata": {
-        "filename": "cover.jpg",
-        "ext": ".jpg",
-        "path": "/podcasts/Welcome to Night Vale/cover.jpg",
-        "relPath": "cover.jpg",
-        "size": 52993,
-        "mtimeMs": 1667326662178,
-        "ctimeMs": 1667326662184,
-        "birthtimeMs": 1667326662090
-      },
-      "addedAt": 1667327311529,
-      "updatedAt": 1667327311529,
-      "fileType": "image"
-    }
-  ]
-}
-```
-
-This endpoint deletes a podcast episode from the database. If providing the `hard` parameter, the file will be deleted as well.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/podcasts/<ID>/episode/<EpisodeID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the podcast library item.
-EpisodeID | The ID of the podcast episode.
-
-### Query Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`hard` | Binary | Whether to delete the podcast episode files from the server. `0` for false, `1` for true.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | [Library Item](#library-item)
-403 | Forbidden | The user is not allowed to access the library item. A user with delete permissions is required to delete podcast episodes. |
 404 | Not Found | No library item with the given ID exists, or no episode with the given ID exists. |
 500 | Internal Server Error | The library item is not a podcast. |

--- a/source/includes/_rss_feeds.md
+++ b/source/includes/_rss_feeds.md
@@ -1,68 +1,30 @@
 # RSS Feeds
 
-## Open an RSS Feed for a Library Item
+## Close an RSS Feed
 
 ```shell
-curl -X POST "https://abs.example.com/api/feeds/item/li_bufnnmp4y5o2gbbxfm/open" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"serverAddress": "https://abs.example.com", "slug": "li_bufnnmp4y5o2gbbxfm"}'
+curl -X POST "https://abs.example.com/api/feeds/li_bufnnmp4y5o2gbbxfm/close" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
 ```
 
-> The above command returns JSON structured like this:
-
-```json
-{
-  "feed": {
-    "id": "li_bufnnmp4y5o2gbbxfm",
-    "entityType": "item",
-    "entityId": "li_bufnnmp4y5o2gbbxfm",
-    "feedUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm",
-    "meta": {
-      "title": "Welcome to Night Vale",
-      "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-      "preventIndexing": true,
-      "ownerName": null,
-      "ownerEmail": null
-    }
-  }
-}
-```
-
-This endpoint opens an RSS feed for a library item.
+This endpoint closes an RSS feed.
 
 ### HTTP Request
 
-`POST http://abs.example.com/api/feeds/item/<LibraryItemID>/open`
+`POST http://abs.example.com/api/feeds/<ID>/close`
 
 ### URL Parameters
 
 Parameter | Description
 --------- | -----------
-LibraryItemID | The ID of the library item.
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`serverAddress` | String | The URL address of the server.
-`slug` | String | The slug (the last part of the URL) to use for the RSS feed.
+ID | The ID of the RSS feed.
 
 ### Response
 
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-400 | Bad Request | The `serverAddress` and `slug` parameters are required, or the item does not have audio tracks, or the `slug` is already in use. |
-403 | Forbidden | An admin user is required to open an RSS feed. |
-404 | Not Found | No library item with the given ID exists. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`feed` | [RSS Feed Minified](#rss-feed-minified) Object | The RSS feed that was opened.
-
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | An admin user is required to close an RSS feed.
 
 ## Open an RSS Feed for a Collection
 
@@ -120,6 +82,70 @@ Status | Meaning | Description | Schema
 400 | Bad Request | The `serverAddress` and `slug` parameters are required, or the collection does not have audio tracks, or the `slug` is already in use. |
 403 | Forbidden | An admin user is required to open an RSS feed. |
 404 | Not Found | No collection with the given ID exists. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`feed` | [RSS Feed Minified](#rss-feed-minified) Object | The RSS feed that was opened.
+
+
+## Open an RSS Feed for a Library Item
+
+```shell
+curl -X POST "https://abs.example.com/api/feeds/item/li_bufnnmp4y5o2gbbxfm/open" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"serverAddress": "https://abs.example.com", "slug": "li_bufnnmp4y5o2gbbxfm"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "feed": {
+    "id": "li_bufnnmp4y5o2gbbxfm",
+    "entityType": "item",
+    "entityId": "li_bufnnmp4y5o2gbbxfm",
+    "feedUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm",
+    "meta": {
+      "title": "Welcome to Night Vale",
+      "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+      "preventIndexing": true,
+      "ownerName": null,
+      "ownerEmail": null
+    }
+  }
+}
+```
+
+This endpoint opens an RSS feed for a library item.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/feeds/item/<LibraryItemID>/open`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+LibraryItemID | The ID of the library item.
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`serverAddress` | String | The URL address of the server.
+`slug` | String | The slug (the last part of the URL) to use for the RSS feed.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+400 | Bad Request | The `serverAddress` and `slug` parameters are required, or the item does not have audio tracks, or the `slug` is already in use. |
+403 | Forbidden | An admin user is required to open an RSS feed. |
+404 | Not Found | No library item with the given ID exists. |
 
 #### Response Schema
 
@@ -190,30 +216,3 @@ Status | Meaning | Description | Schema
 Attribute | Type | Description
 --------- | ---- | -----------
 `feed` | [RSS Feed Minified](#rss-feed-minified) Object | The RSS feed that was opened.
-
-
-## Close an RSS Feed
-
-```shell
-curl -X POST "https://abs.example.com/api/feeds/li_bufnnmp4y5o2gbbxfm/close" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint closes an RSS feed.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/feeds/<ID>/close`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the RSS feed.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | An admin user is required to close an RSS feed.

--- a/source/includes/_schemas.md
+++ b/source/includes/_schemas.md
@@ -1,5 +1,692 @@
 # Schemas
 
+## Audio Bookmark
+
+> Audio Bookmark
+
+```json
+{
+  "libraryItemId": "li_8gch9ve09orgn4fdz8",
+  "title": "the good part",
+  "time": 16,
+  "createdAt": 1668120083771
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`libraryItemId` | String | The ID of the library item the bookmark is for.
+`title` | String | The title of the bookmark.
+`time` | Integer | The time (in seconds) the bookmark is at in the book.
+`createdAt` | Integer | The time (in ms since POSIX epoch) when the bookmark was created.
+
+
+## Audio File
+
+> Audio File
+
+```json
+{
+  "index": 1,
+  "ino": "649644248522215260",
+  "metadata": {...},
+  "addedAt": 1650621074131,
+  "updatedAt": 1651830828023,
+  "trackNumFromMeta": 1,
+  "discNumFromMeta": null,
+  "trackNumFromFilename": 1,
+  "discNumFromFilename": null,
+  "manuallyVerified": false,
+  "invalid": false,
+  "exclude": false,
+  "error": null,
+  "format": "MP2/3 (MPEG audio layer 2/3)",
+  "duration": 6004.6675,
+  "bitRate": 64000,
+  "language": null,
+  "codec": "mp3",
+  "timeBase": "1/14112000",
+  "channels": 2,
+  "channelLayout": "stereo",
+  "chapters": [],
+  "embeddedCoverArt": null,
+  "metaTags": {...},
+  "mimeType": "audio/mpeg"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`index` | Integer | The index of the audio file.
+`ino` | String | The inode of the audio file.
+`metadata` | [File Metadata](#file-metadata) Object | The audio file's metadata.
+`addedAt` | Integer | The time (in ms since POSIX epoch) when the audio file was added to the library.
+`updatedAt` | Integer | The time (in ms since POSIX epoch) when the audio file last updated. (Read Only)
+`trackNumFromMeta` | Integer or null | The track number of the audio file as pulled from the file's metadata. Will be `null` if unknown.
+`discNumFromMeta` | Integer or null | The disc number of the audio file as pulled from the file's metadata. Will be `null` if unknown.
+`trackNumFromFilename` | Integer or null | The track number of the audio file as determined from the file's name. Will be `null` if unknown.
+`discNumFromFilename` | Integer or null | The track number of the audio file as determined from the file's name. Will be `null` if unknown.
+`manuallyVerified` | Boolean | Whether the audio file has been manually verified by a user.
+`invalid` | Boolean | Whether the audio file is missing from the server.
+`exclude` | Boolean | Whether the audio file has been marked for exclusion.
+`error` | String or null | Any error with the audio file. Will be `null` if there is none.
+`format` | String | The format of the audio file.
+`duration` | Float | The total length (in seconds) of the audio file.
+`bitRate` | Integer | The bit rate (in bit/s) of the audio file.
+`language` | String or null | The language of the audio file.
+`codec` | String | The codec of the audio file.
+`timeBase` | String | The time base of the audio file.
+`channels` | Integer | The number of channels the audio file has.
+`channelLayout` | String | The layout of the audio file's channels.
+`chapters` | Array of [Book Chapter](#book-chapter) | If the audio file is part of an audiobook, the chapters the file contains.
+`embeddedCoverArt` | String or null | The type of embedded cover art in the audio file. Will be `null` if none exists.
+`metaTags` | [Audio Meta Tags](#audio-meta-tags) Object | The audio metadata tags from the audio file.
+`mimeType` | String | The MIME type of the audio file.
+
+
+## Audio Meta Tags
+
+> Audio Meta Tags
+
+```json
+{
+  "tagAlbum": "SOT Bk01",
+  "tagArtist": "Terry Goodkind",
+  "tagGenre": "Audiobook Fantasy",
+  "tagTitle": "Wizards First Rule 01",
+  "tagSeries": null,
+  "tagSeriesPart": null,
+  "tagTrack": "01/20",
+  "tagDisc": null,
+  "tagSubtitle": null,
+  "tagAlbumArtist": "Terry Goodkind",
+  "tagDate": null,
+  "tagComposer": "Terry Goodkind",
+  "tagPublisher": null,
+  "tagComment": null,
+  "tagDescription": null,
+  "tagEncoder": null,
+  "tagEncodedBy": null,
+  "tagIsbn": null,
+  "tagLanguage": null,
+  "tagASIN": null,
+  "tagOverdriveMediaMarker": null,
+  "tagOriginalYear": null,
+  "tagReleaseCountry": null,
+  "tagReleaseType": null,
+  "tagReleaseStatus": null,
+  "tagISRC": null,
+  "tagMusicBrainzTrackId": null,
+  "tagMusicBrainzAlbumId": null,
+  "tagMusicBrainzAlbumArtistId": null,
+  "tagMusicBrainzArtistId": null
+}
+```
+
+[ID3](https://en.wikipedia.org/wiki/ID3) metadata tags pulled from the audio file on import.
+Only non-null tags will be returned in requests.
+
+
+## Audio Track
+
+> Audio Track
+
+```json
+{
+  "index": 1,
+  "startOffset": 0,
+  "duration": 33854.905,
+  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+  "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+  "mimeType": "audio/mpeg",
+  "metadata": {...}
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`index` | Integer | The index of the audio track.
+`startOffset` | Float | When in the audio file (in seconds) the track starts.
+`duration` | Float | The length (in seconds) of the audio track.
+`title` | String | The filename of the audio file the audio track belongs to.
+`contentUrl` | String | The URL path of the audio file.
+`mimeType` | String | The MIME type of the audio file.
+`metadata` | [File Metadata](#file-metadata) Object or null | The metadata of the audio file.
+
+
+## Author
+
+> Author
+
+```json
+{
+  "id": "aut_z3leimgybl7uf3y4ab",
+  "asin": null,
+  "name": "Terry Goodkind",
+  "description": null,
+  "imagePath": null,
+  "addedAt": 1650621073750,
+  "updatedAt": 1650621073750
+}
+```
+
+> Author Minified
+
+```json
+{
+  "id": "aut_z3leimgybl7uf3y4ab",
+  "name": "Terry Goodkind"
+}
+```
+
+> Author Expanded
+
+```json
+{
+  "id": "aut_z3leimgybl7uf3y4ab",
+  "asin": null,
+  "name": "Terry Goodkind",
+  "description": null,
+  "imagePath": null,
+  "addedAt": 1650621073750,
+  "updatedAt": 1650621073750,
+  "numBooks": 1
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the author.
+`asin` | String or null | The ASIN of the author. Will be `null` if unknown.
+`name` | String | The name of the author.
+`description` | String or null | A description of the author. Will be `null` if there is none.
+`imagePath` | String or null | The absolute path for the author image. Will be `null` if there is no image.
+`addedAt` | Integer | The time (in ms since POSIX epoch) when the author was added.
+`updatedAt` | Integer | The time (in ms since POSIX epoch) when the author was last updated.
+
+### Author Minified
+
+#### Removed Attributes
+
+* `asin`
+* `description`
+* `imagePath`
+* `addedAt`
+* `updatedAt`
+
+### Author Expanded
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`numBooks` | Integer | The number of books associated with the author in the library.
+
+
+## Backup
+
+> Backup
+
+```json
+{
+  "id": "2022-11-14T0130",
+  "backupMetadataCovers": true,
+  "backupDirPath": "/metadata/backups",
+  "datePretty": "Mon, Nov 14 2022 01:30",
+  "fullPath": "/metadata/backups/2022-11-14T0130.audiobookshelf",
+  "path": "backups/2022-11-14T0130.audiobookshelf",
+  "filename": "2022-11-14T0130.audiobookshelf",
+  "fileSize": 7776983,
+  "createdAt": 1668411000329,
+  "serverVersion": "2.2.4"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the backup. Will be the date and time when the backup was created.
+`backupMetadataCovers` | Boolean | Whether the backup includes library item covers and author images located in metadata.
+`backupDirPath` | String | The backup directory path.
+`datePretty` | String | The date and time when the backup was created in a human-readable format.
+`fullPath` | String | The full path of the backup on the server.
+`path` | String | The path of the backup relative to the metadata directory.
+`filename` | String | The filename of the backup.
+`fileSize` | Integer | The size (in bytes) of the backup file.
+`createdAt` | Integer | The time (in ms since POSIX epoch) when the backup was created.
+`serverVersion` | String | The version of the server when the backup was created.
+
+
+## Book
+
+> Book
+
+```json
+{
+  "libraryItemId": "li_8gch9ve09orgn4fdz8",
+  "metadata": {...},
+  "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+  "tags": [
+    "Favorite"
+  ],
+  "audioFiles": [...],
+  "chapters": [...],
+  "missingParts": [...],
+  "ebookFile": null
+}
+```
+
+> Book Minified
+
+```json
+{
+  "metadata": {...},
+  "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+  "tags": [
+    "Favorite"
+  ],
+  "numTracks": 1,
+  "numAudioFiles": 1,
+  "numChapters": 1,
+  "numMissingParts": 0,
+  "numInvalidAudioFiles": 0,
+  "duration": 33854.905,
+  "size": 268824228,
+  "ebookFormat": null
+}
+```
+
+> Book Expanded
+
+```json
+{
+  "libraryItemId": "li_8gch9ve09orgn4fdz8",
+  "metadata": {...},
+  "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
+  "tags": [
+    "Favorite"
+  ],
+  "audioFiles": [...],
+  "chapters": [...],
+  "duration": 33854.905,
+  "size": 268824228,
+  "tracks": [...],
+  "missingParts": [...],
+  "ebookFile": null
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`libraryItemId` | String | The ID of the library item that contains the book.
+`metadata` | [Book Metadata](#book-metadata) Object | The book's metadata.
+`coverPath` | String or null | The absolute path on the server of the cover file. Will be `null` if there is no cover.
+`tags` | Array of String | The book's tags.
+`audioFiles` | Array of [Audio File](#audio-file) | The book's audio files.
+`chapters` | Array of [Book Chapter](#book-chapter) | The book's chapters.
+`missingParts` | Array of Integer | Any parts missing from the book by track index.
+`ebookFile` | [EBook File](#ebook-file) Object or null | The book's ebook file. Will be `null` if this is an audiobook.
+
+### Book Minified
+
+#### Removed Attributes
+
+* `libraryItemId`
+* `audioFiles`
+* `chapters`
+* `missingParts`
+* `ebookFile`
+
+#### Modified Attributes
+
+* `metadata` is [Book Metadata Minified](#book-metadata-minified)
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`numTracks` | Integer | The number of tracks the book's audio files have.
+`numAudioFiles` | Integer | The number of audio files the book has.
+`numChapters` | Integer | The number of chapters the book has.
+`numMissingParts` | Integer | The total number of missing parts the book has.
+`numInvalidAudioFiles` | Integer | The number of invalid audio files the book has.
+`duration` | Float | The total length (in seconds) of the book.
+`size` | Integer | The total size (in bytes) of the book.
+`ebookFormat` | String or null | The format of ebook of the book. Will be `null` if the book is an audiobook.
+
+### Book Expanded
+
+#### Modified Attributes
+
+* `metadata` is [Book Metadata Expanded](#book-metadata-expanded)
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`duration` | Float | The total length (in seconds) of the book.
+`size` | Integer | The total size (in bytes) of the book.
+`tracks` | Array of [Audio Track](#audio-track) | The book's audio tracks from the audio files.
+
+
+## Book Chapter
+
+> Book Chapter
+
+```json
+{
+  "id": 0,
+  "start": 0,
+  "end": 6004.6675,
+  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | Integer | The ID of the book chapter.
+`start` | Float | When in the book (in seconds) the chapter starts.
+`end` | Float | When in the book (in seconds) the chapter ends.
+`title` | String | The title of the chapter.
+
+
+## Book Metadata
+
+> Book Metadata
+
+```json
+{
+  "title": "Wizards First Rule",
+  "subtitle": null,
+  "authors": [...],
+  "narrators": [
+    "Sam Tsoutsouvas"
+  ],
+  "series": [...],
+  "genres": [
+    "Fantasy"
+  ],
+  "publishedYear": "2008",
+  "publishedDate": null,
+  "publisher": "Brilliance Audio",
+  "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+  "isbn": null,
+  "asin": "B002V0QK4C",
+  "language": null,
+  "explicit": false
+}
+```
+
+> Book Metadata Minified
+
+```json
+{
+  "title": "Wizards First Rule",
+  "titleIgnorePrefix": "Wizards First Rule",
+  "subtitle": null,
+  "authorName": "Terry Goodkind",
+  "authorNameLF": "Goodkind, Terry",
+  "narratorName": "Sam Tsoutsouvas",
+  "seriesName": "Sword of Truth",
+  "genres": [
+    "Fantasy"
+  ],
+  "publishedYear": "2008",
+  "publishedDate": null,
+  "publisher": "Brilliance Audio",
+  "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+  "isbn": null,
+  "asin": "B002V0QK4C",
+  "language": null,
+  "explicit": false
+}
+```
+
+> Book Metadata Expanded
+
+```json
+{
+  "title": "Wizards First Rule",
+  "titleIgnorePrefix": "Wizards First Rule",
+  "subtitle": null,
+  "authors": [...],
+  "narrators": [
+    "Sam Tsoutsouvas"
+  ],
+  "series": [...],
+  "genres": [
+    "Fantasy"
+  ],
+  "publishedYear": "2008",
+  "publishedDate": null,
+  "publisher": "Brilliance Audio",
+  "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
+  "isbn": null,
+  "asin": "B002V0QK4C",
+  "language": null,
+  "explicit": false,
+  "authorName": "Terry Goodkind",
+  "authorNameLF": "Goodkind, Terry",
+  "narratorName": "Sam Tsoutsouvas",
+  "seriesName": "Sword of Truth"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`title` | String or null | The title of the book. Will be `null` if unknown.
+`subtitle` | String or null | The subtitle of the book. Will be `null` if there is no subtitle.
+`authors` | Array of [Author Minified](#author-minified) | The authors of the book.
+`narrators` | Array of String | The narrators of the audiobook.
+`series` | Array of [Series Sequence](#series-sequence) | The series the book belongs to.
+`genres` | Array of String | The genres of the book.
+`publishedYear` | String or null | The year the book was published. Will be `null` if unknown.
+`publishedDate` | String or null | The date the book was published. Will be `null` if unknown.
+`publisher` | String or null | The publisher of the book. Will be `null` if unknown.
+`description` | String or null | A description for the book. Will be `null` if empty.
+`isbn` | String or null | The ISBN of the book. Will be `null` if unknown.
+`asin` | String or null | The ASIN of the book. Will be `null` if unknown.
+`language` | String or null | The language of the book. Will be `null` if unknown.
+`explicit` | Boolean | Whether the book has been marked as explicit.
+
+### Book Metadata Minified
+
+#### Removed Attributes
+
+* `authors`
+* `narrators`
+* `series`
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`titleIgnorePrefix` | String | The title of the book with any prefix moved to the end.
+`authorName` | String | The name of the book's author(s).
+`authorNameLF` | String | The name of the book's author(s) with last names first.
+`narratorName` | String | The name of the audiobook's narrator(s).
+`seriesName` | String | The name of the book's series.
+
+### Book Metadata Expanded
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`titleIgnorePrefix` | String | The title of the book with any prefix moved to the end.
+`authorName` | String | The name of the book's author(s).
+`authorNameLF` | String | The name of the book's author(s) with last names first.
+`narratorName` | String | The name of the audiobook's narrator(s).
+`seriesName` | String | The name of the book's series.
+
+
+## Collection
+
+> Collection
+
+```json
+{
+  "id": "col_fpfstanv6gd7tq2qz7",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "Favorites",
+  "description": null,
+  "cover": null,
+  "coverFullPath": null,
+  "books": [...],
+  "lastUpdate": 1650621110769,
+  "createdAt": 1650621073750
+}
+```
+
+> Collection Expanded
+
+```json
+{
+  "id": "col_fpfstanv6gd7tq2qz7",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "Favorites",
+  "description": null,
+  "cover": null,
+  "coverFullPath": null,
+  "books": [...],
+  "lastUpdate": 1650621110769,
+  "createdAt": 1650621073750
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the collection.
+`libraryId` | String | The ID of the library the collection belongs to.
+`userId` | String | The ID of the user that created the collection.
+`name` | String | The name of the collection.
+`description` | String or null | The collection's description. Will be `null` if there is none.
+`cover` | String or null | The path to the collection's cover. Will be `null` if there is no cover.
+`coverFullPath` | String or null | The full path to collection's cover. Will be `null` if there is no cover.
+`books` | Array of [Library Item](#library-item) | The books that belong to the collection.
+`lastUpdate` | Integer | The time (in ms since POSIX epoch) when the collection was last updated.
+`createdAt` | Integer | The time (in ms since POSIX epoch) when the collection was created.
+
+### Collection Expanded
+
+#### Modified Attributes
+
+* `books` is an Array of [Library Item Expanded](#library-item-expanded).
+
+
+## Device Info
+
+> Device Info
+
+```json
+{
+  "ipAddress": "192.168.1.118",
+  "browserName": "Firefox",
+  "browserVersion": "106.0",
+  "osName": "Linux",
+  "osVersion": "x86_64",
+  "deviceType": null,
+  "manufacturer": null,
+  "model": null,
+  "sdkVersion": null,
+  "serverVersion": "2.2.2"
+}
+```
+
+Any attributes with a `null` value will be filtered out in responses.
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`ipAddress` | String or null | The IP address that the request came from.
+`browserName` | String or null | The browser name, taken from the user agent.
+`browserVersion` | String or null | The browser version, taken from the user agent.
+`osName` | String or null | The name of OS, taken from the user agent.
+`osVersion` | String or null | The version of the OS, taken from the user agent.
+`deviceType` | String or null | The device type, taken from the user agent.
+`manufacturer` | String or null | The client device's manufacturer, as provided in the request.
+`model` | String or null | The client device's model, as provided in the request.
+`sdkVersion` | Integer or null | For an Android device, the Android SDK version of the client, as provided in the request.
+`serverVersion` | String or null | The version of the server at the time of the request.
+
+
+## EBook File
+
+> EBook File
+
+```json
+{
+  "ino" : "9463162",
+  "metadata": {...},
+  "ebookFormat": "epub",
+  "addedAt": 1650621073750,
+  "updatedAt": 1650621110769
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`ino` | String | The inode of the ebook file.
+`metadata` | [File Metadata](#file-metadata) Object | The metadata of the ebook file.
+`ebookFormat` | String | The ebook format of the ebook file.
+`addedAt` | Integer | The time (in ms since POSIX epoch) when the library file was added.
+`updatedAt` | Integer | The time (in ms since POSIX epoch) when the library file was last updated.
+
+
+## File Metadata
+
+> File Metadata
+
+```json
+{
+  "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+  "ext": ".mp3",
+  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+  "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
+  "size": 48037888,
+  "mtimeMs": 1632223180278,
+  "ctimeMs": 1645978261001,
+  "birthtimeMs": 0
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`filename` | String | The filename of the file.
+`ext` | String | The file extension of the file.
+`path` | String | The absolute path on the server of the file.
+`relPath` | String | The path of the file, relative to the book's or podcast's folder.
+`size` | Integer | The size (in bytes) of the file.
+`mtimeMs` | Integer | The time (in ms since POSIX epoch) when the file was last modified on disk.
+`ctimeMs` | Integer | The time (in ms since POSIX epoch) when the file status was changed on disk.
+`birthtimeMs` | Integer | The time (in ms since POSIX epoch) when the file was created on disk. Will be `0` if unknown.
+
+
+## Folder
+
+> Folder
+
+```json
+{
+  "id": "fol_bev1zuxhb0j0s1wehr",
+  "fullPath": "/podcasts",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "addedAt": 1650462940610
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the folder. (Read Only) 
+`fullPath` | String | The path on the server for the folder. (Read Only)
+`libraryId` | String | The ID of the library the folder belongs to. (Read Only)
+`addedAt` | Integer | The time (in ms since POSIX epoch) when the folder was added. (Read Only)
+
+<aside class="notice">
+  Only provide <code>fullPath</code> when creating a new folder. The other attributes will be automatically set.
+</aside>
+
+
 ## Library
 
 > Library
@@ -33,27 +720,27 @@ Attribute | Type | Description
 `lastUpdate` | Integer | The time (in ms since POSIX epoch) when the library was last updated. (Read Only)
 
 
-## Library Settings
+## Library File
 
-> Library Settings
+> Library File
 
 ```json
 {
-  "coverAspectRatio": 1,
-  "disableWatcher": false,
-  "skipMatchingMediaWithAsin": false,
-  "skipMatchingMediaWithIsbn": false,
-  "autoScanCronExpression": null
+  "ino": "649644248522215260",
+  "metadata": {...},
+  "addedAt": 1650621052494,
+  "updatedAt": 1650621052494,
+  "fileType": "audio"
 }
 ```
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`coverAspectRatio` | Integer | Whether the library should use square book covers. Must be `0` (for false) or `1` (for true).
-`disableWatcher` | Boolean | Whether to disable the folder watcher for the library.
-`skipMatchingMediaWithAsin` | Boolean | Whether to skip matching books that already have an ASIN.
-`skipMatchingMediaWithIsbn` | Boolean | Whether to skip matching books that already have an ISBN.
-`autoScanCronExpression` | String or null | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to automatically scan the library folders. If `null`, automatic scanning will be disabled.
+`ino` | String | The inode of the library file.
+`metadata` | [File Metadata](#file-metadata) Object | The metadata for the library file.
+`addedAt` | Integer | The time (in ms since POSIX epoch) when the library file was added.
+`updatedAt` | Integer | The time (in ms since POSIX epoch) when the library file was last updated.
+`fileType` | String | The type of file that the library file is (audio, image, etc.).
 
 
 ## Library Filter Data
@@ -93,31 +780,6 @@ Attribute | Type | Description
 `series` | Array of [Series](#series) | The series in the library. The series will only have their `id` and `name`.
 `narrators` | Array of String | The narrators of books in the library.
 `languages` | Array of String | The languages of books in the library.
-
-
-## Folder
-
-> Folder
-
-```json
-{
-  "id": "fol_bev1zuxhb0j0s1wehr",
-  "fullPath": "/podcasts",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "addedAt": 1650462940610
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the folder. (Read Only) 
-`fullPath` | String | The path on the server for the folder. (Read Only)
-`libraryId` | String | The ID of the library the folder belongs to. (Read Only)
-`addedAt` | Integer | The time (in ms since POSIX epoch) when the folder was added. (Read Only)
-
-<aside class="notice">
-  Only provide <code>fullPath</code> when creating a new folder. The other attributes will be automatically set.
-</aside>
 
 
 ## Library Item
@@ -254,1268 +916,27 @@ Attribute | Type | Description
 `size` | Integer | The total size (in bytes) of the library item.
 
 
-## Book
+## Library Settings
 
-> Book
-
-```json
-{
-  "libraryItemId": "li_8gch9ve09orgn4fdz8",
-  "metadata": {...},
-  "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-  "tags": [
-    "Favorite"
-  ],
-  "audioFiles": [...],
-  "chapters": [...],
-  "missingParts": [...],
-  "ebookFile": null
-}
-```
-
-> Book Minified
+> Library Settings
 
 ```json
 {
-  "metadata": {...},
-  "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-  "tags": [
-    "Favorite"
-  ],
-  "numTracks": 1,
-  "numAudioFiles": 1,
-  "numChapters": 1,
-  "numMissingParts": 0,
-  "numInvalidAudioFiles": 0,
-  "duration": 33854.905,
-  "size": 268824228,
-  "ebookFormat": null
-}
-```
-
-> Book Expanded
-
-```json
-{
-  "libraryItemId": "li_8gch9ve09orgn4fdz8",
-  "metadata": {...},
-  "coverPath": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/cover.jpg",
-  "tags": [
-    "Favorite"
-  ],
-  "audioFiles": [...],
-  "chapters": [...],
-  "duration": 33854.905,
-  "size": 268824228,
-  "tracks": [...],
-  "missingParts": [...],
-  "ebookFile": null
+  "coverAspectRatio": 1,
+  "disableWatcher": false,
+  "skipMatchingMediaWithAsin": false,
+  "skipMatchingMediaWithIsbn": false,
+  "autoScanCronExpression": null
 }
 ```
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`libraryItemId` | String | The ID of the library item that contains the book.
-`metadata` | [Book Metadata](#book-metadata) Object | The book's metadata.
-`coverPath` | String or null | The absolute path on the server of the cover file. Will be `null` if there is no cover.
-`tags` | Array of String | The book's tags.
-`audioFiles` | Array of [Audio File](#audio-file) | The book's audio files.
-`chapters` | Array of [Book Chapter](#book-chapter) | The book's chapters.
-`missingParts` | Array of Integer | Any parts missing from the book by track index.
-`ebookFile` | [EBook File](#ebook-file) Object or null | The book's ebook file. Will be `null` if this is an audiobook.
-
-### Book Minified
-
-#### Removed Attributes
-
-* `libraryItemId`
-* `audioFiles`
-* `chapters`
-* `missingParts`
-* `ebookFile`
-
-#### Modified Attributes
-
-* `metadata` is [Book Metadata Minified](#book-metadata-minified)
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`numTracks` | Integer | The number of tracks the book's audio files have.
-`numAudioFiles` | Integer | The number of audio files the book has.
-`numChapters` | Integer | The number of chapters the book has.
-`numMissingParts` | Integer | The total number of missing parts the book has.
-`numInvalidAudioFiles` | Integer | The number of invalid audio files the book has.
-`duration` | Float | The total length (in seconds) of the book.
-`size` | Integer | The total size (in bytes) of the book.
-`ebookFormat` | String or null | The format of ebook of the book. Will be `null` if the book is an audiobook.
-
-### Book Expanded
-
-#### Modified Attributes
-
-* `metadata` is [Book Metadata Expanded](#book-metadata-expanded)
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`duration` | Float | The total length (in seconds) of the book.
-`size` | Integer | The total size (in bytes) of the book.
-`tracks` | Array of [Audio Track](#audio-track) | The book's audio tracks from the audio files.
-
-
-## Book Metadata
-
-> Book Metadata
-
-```json
-{
-  "title": "Wizards First Rule",
-  "subtitle": null,
-  "authors": [...],
-  "narrators": [
-    "Sam Tsoutsouvas"
-  ],
-  "series": [...],
-  "genres": [
-    "Fantasy"
-  ],
-  "publishedYear": "2008",
-  "publishedDate": null,
-  "publisher": "Brilliance Audio",
-  "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-  "isbn": null,
-  "asin": "B002V0QK4C",
-  "language": null,
-  "explicit": false
-}
-```
-
-> Book Metadata Minified
-
-```json
-{
-  "title": "Wizards First Rule",
-  "titleIgnorePrefix": "Wizards First Rule",
-  "subtitle": null,
-  "authorName": "Terry Goodkind",
-  "authorNameLF": "Goodkind, Terry",
-  "narratorName": "Sam Tsoutsouvas",
-  "seriesName": "Sword of Truth",
-  "genres": [
-    "Fantasy"
-  ],
-  "publishedYear": "2008",
-  "publishedDate": null,
-  "publisher": "Brilliance Audio",
-  "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-  "isbn": null,
-  "asin": "B002V0QK4C",
-  "language": null,
-  "explicit": false
-}
-```
-
-> Book Metadata Expanded
-
-```json
-{
-  "title": "Wizards First Rule",
-  "titleIgnorePrefix": "Wizards First Rule",
-  "subtitle": null,
-  "authors": [...],
-  "narrators": [
-    "Sam Tsoutsouvas"
-  ],
-  "series": [...],
-  "genres": [
-    "Fantasy"
-  ],
-  "publishedYear": "2008",
-  "publishedDate": null,
-  "publisher": "Brilliance Audio",
-  "description": "The masterpiece that started Terry Goodkind's New York Times bestselling epic Sword of Truth In the aftermath of the brutal murder of his father, a mysterious woman, Kahlan Amnell, appears in Richard Cypher's forest sanctuary seeking help...and more. His world, his very beliefs, are shattered when ancient debts come due with thundering violence. In a dark age it takes courage to live, and more than mere courage to challenge those who hold dominion, Richard and Kahlan must take up that challenge or become the next victims. Beyond awaits a bewitching land where even the best of their hearts could betray them. Yet, Richard fears nothing so much as what secrets his sword might reveal about his own soul. Falling in love would destroy them - for reasons Richard can't imagine and Kahlan dare not say. In their darkest hour, hunted relentlessly, tormented by treachery and loss, Kahlan calls upon Richard to reach beyond his sword - to invoke within himself something more noble. Neither knows that the rules of battle have just changed...or that their time has run out. Wizard's First Rule is the beginning. One book. One Rule. Witness the birth of a legend.",
-  "isbn": null,
-  "asin": "B002V0QK4C",
-  "language": null,
-  "explicit": false,
-  "authorName": "Terry Goodkind",
-  "authorNameLF": "Goodkind, Terry",
-  "narratorName": "Sam Tsoutsouvas",
-  "seriesName": "Sword of Truth"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`title` | String or null | The title of the book. Will be `null` if unknown.
-`subtitle` | String or null | The subtitle of the book. Will be `null` if there is no subtitle.
-`authors` | Array of [Author Minified](#author-minified) | The authors of the book.
-`narrators` | Array of String | The narrators of the audiobook.
-`series` | Array of [Series Sequence](#series-sequence) | The series the book belongs to.
-`genres` | Array of String | The genres of the book.
-`publishedYear` | String or null | The year the book was published. Will be `null` if unknown.
-`publishedDate` | String or null | The date the book was published. Will be `null` if unknown.
-`publisher` | String or null | The publisher of the book. Will be `null` if unknown.
-`description` | String or null | A description for the book. Will be `null` if empty.
-`isbn` | String or null | The ISBN of the book. Will be `null` if unknown.
-`asin` | String or null | The ASIN of the book. Will be `null` if unknown.
-`language` | String or null | The language of the book. Will be `null` if unknown.
-`explicit` | Boolean | Whether the book has been marked as explicit.
-
-### Book Metadata Minified
-
-#### Removed Attributes
-
-* `authors`
-* `narrators`
-* `series`
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`titleIgnorePrefix` | String | The title of the book with any prefix moved to the end.
-`authorName` | String | The name of the book's author(s).
-`authorNameLF` | String | The name of the book's author(s) with last names first.
-`narratorName` | String | The name of the audiobook's narrator(s).
-`seriesName` | String | The name of the book's series.
-
-### Book Metadata Expanded
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`titleIgnorePrefix` | String | The title of the book with any prefix moved to the end.
-`authorName` | String | The name of the book's author(s).
-`authorNameLF` | String | The name of the book's author(s) with last names first.
-`narratorName` | String | The name of the audiobook's narrator(s).
-`seriesName` | String | The name of the book's series.
-
-
-## Book Chapter
-
-> Book Chapter
-
-```json
-{
-  "id": 0,
-  "start": 0,
-  "end": 6004.6675,
-  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | Integer | The ID of the book chapter.
-`start` | Float | When in the book (in seconds) the chapter starts.
-`end` | Float | When in the book (in seconds) the chapter ends.
-`title` | String | The title of the chapter.
-
-
-## Podcast
-
-> Podcast
-
-```json
-{
-  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-  "metadata": {...},
-  "coverPath": "/podcasts/Welcome to Night Vale/cover.jpg",
-  "tags": [
-    "Favorite"
-  ],
-  "episodes": [...],
-  "autoDownloadEpisodes": true,
-  "autoDownloadSchedule": "0 0 * * 1",
-  "lastEpisodeCheck": 1667326662087,
-  "maxEpisodesToKeep": 0,
-  "maxNewEpisodesToDownload": 3
-}
-```
-
-> Podcast Minified
-
-```json
-{
-  "metadata": {...},
-  "coverPath": "/podcasts/Welcome to Night Vale/cover.jpg",
-  "tags": [
-    "Favorite"
-  ],
-  "numEpisodes": 1,
-  "autoDownloadEpisodes": true,
-  "autoDownloadSchedule": "0 0 * * 1",
-  "lastEpisodeCheck": 1667326662087,
-  "maxEpisodesToKeep": 0,
-  "maxNewEpisodesToDownload": 3,
-  "size": 23706728
-}
-```
-
-> Podcast Expanded
-
-```json
-{
-  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-  "metadata": {...},
-  "coverPath": "/podcasts/Welcome to Night Vale/cover.jpg",
-  "tags": [
-    "Favorite"
-  ],
-  "episodes": [...],
-  "autoDownloadEpisodes": true,
-  "autoDownloadSchedule": "0 0 * * 1",
-  "lastEpisodeCheck": 1667326662087,
-  "maxEpisodesToKeep": 0,
-  "maxNewEpisodesToDownload": 3,
-  "size": 23706728
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`libraryItemId` | String | The ID of the library item that contains the podcast.
-`metadata` | [Podcast Metadata](#podcast-metadata) Object | The metadata for the podcast.
-`coverPath` | String or null | The absolute path on the server of the cover file. Will be `null` if there is no cover.
-`tags` | Array of String | The podcast's tags.
-`episodes` | Array of [Podcast Episode](#podcast-episode) | The downloaded episodes of the podcast.
-`autoDownloadEpisodes` | Boolean | Whether the server will automatically download podcast episodes according to the schedule.
-`autoDownloadSchedule` | String | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to automatically download podcast episodes. Will not exist if `autoDownloadEpisodes` is `false`.
-`lastEpisodeCheck` | Integer | The time (in ms since POSIX epoch) when the podcast was checked for new episodes.
-`maxEpisodesToKeep` | Integer | The maximum number of podcast episodes to keep when automatically downloading new episodes. Episodes beyond this limit will be deleted. If `0`, all episodes will be kept.
-`maxNewEpisodesToDownload` | Integer | The maximum number of podcast episodes to download when automatically downloading new episodes. If `0`, all episodes will be downloaded.
-
-### Podcast Minified
-
-#### Removed Attributes
-
-* `libraryItemId`
-* `episodes`
-
-#### Modified Attributes
-
-* `metadata` is [Podcast Metadata Minified](#podcast-metadata-minified)
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`numEpisodes` | Integer | The number of downloaded episodes for the podcast.
-`size` | Integer | The total size (in bytes) of the podcast.
-
-### Podcast Expanded
-
-#### Modified Attributes
-
-* `metadata` is [Podcast Metadata Expanded](#podcast-metadata-expanded)
-* `episodes` is an Array of [Podcast Episodes Expanded](#podcast-episode-expanded)
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`size` | Integer | The total size (in bytes) of the podcast.
-
-
-## Podcast Metadata
-
-> Podcast Metadata
-
-```json
-{
-  "title": "Welcome to Night Vale",
-  "author": "Night Vale Presents",
-  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-  "releaseDate": "2022-10-20T19:00:00Z",
-  "genres": [
-    "Science Fiction",
-    "Podcasts",
-    "Fiction"
-  ],
-  "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
-  "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
-  "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
-  "itunesId": 536258179,
-  "itunesArtistId": 718704794,
-  "explicit": false,
-  "language": null,
-  "type": "episodic"
-}
-```
-
-> Podcast Metadata Minified
-
-```json
-{
-  "title": "Welcome to Night Vale",
-  "titleIgnorePrefix": "Welcome to Night Vale",
-  "author": "Night Vale Presents",
-  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-  "releaseDate": "2022-10-20T19:00:00Z",
-  "genres": [
-    "Science Fiction",
-    "Podcasts",
-    "Fiction"
-  ],
-  "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
-  "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
-  "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
-  "itunesId": 536258179,
-  "itunesArtistId": 718704794,
-  "explicit": false,
-  "language": null,
-  "type": "episodic"
-}
-```
-
-> Podcast Metadata Expanded
-
-```json
-{
-  "title": "Welcome to Night Vale",
-  "titleIgnorePrefix": "Welcome to Night Vale",
-  "author": "Night Vale Presents",
-  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-  "releaseDate": "2022-10-20T19:00:00Z",
-  "genres": [
-    "Science Fiction",
-    "Podcasts",
-    "Fiction"
-  ],
-  "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
-  "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
-  "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
-  "itunesId": 536258179,
-  "itunesArtistId": 718704794,
-  "explicit": false,
-  "language": null,
-  "type": "episodic"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`title` | String or null | The title of the podcast. Will be `null` if unknown.
-`author` | String or null | The author of the podcast. Will be `null` if unknown.
-`description` | String or null | The description for the podcast. Will be `null` if unknown.
-`releaseDate` | String or null | The release date of the podcast. Will be `null` if unknown.
-`genres` | Array of String | The podcast's genres.
-`feedUrl` | String or null | A URL of an RSS feed for the podcast. Will be `null` if unknown.
-`imageUrl` | String or null | A URL of a cover image for the podcast. Will be `null` if unknown.
-`itunesPageUrl` | String or null | A URL of an iTunes page for the podcast. Will be `null` if unknown.
-`itunesId` | Integer or null | The iTunes ID for the podcast. Will be `null` if unknown.
-`itunesArtistId` | Integer or null | The iTunes Artist ID for the author of the podcast. Will be `null` if unknown.
-`explicit` | Boolean | Whether the podcast has been marked as explicit.
-`language` | String or null | The language of the podcast. Will be `null` if unknown.
-`type` | String or null | The type of the podcast.
-
-### Podcast Metadata Minified
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`titleIgnorePrefix` | String | The title of the podcast with any prefix moved to the end.
-
-### Podcast Metadata Expanded
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`titleIgnorePrefix` | String | The title of the podcast with any prefix moved to the end.
-
-
-## Podcast Episode
-
-> Podcast Episode
-
-```json
-{
-  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-  "id": "ep_lh6ko39pumnrma3dhv",
-  "index": 1,
-  "season": "",
-  "episode": "",
-  "episodeType": "full",
-  "title": "1 - Pilot",
-  "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
-  "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
-  "enclosure": {...},
-  "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
-  "audioFile": {...},
-  "publishedAt": 1339761600000,
-  "addedAt": 1667326679503,
-  "updatedAt": 1667326679503
-}
-```
-
-> Podcast Episode Expanded
-
-```json
-{
-  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-  "id": "ep_lh6ko39pumnrma3dhv",
-  "index": 1,
-  "season": "",
-  "episode": "",
-  "episodeType": "full",
-  "title": "1 - Pilot",
-  "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
-  "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
-  "enclosure": {...},
-  "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
-  "audioFile": {...},
-  "audioTrack": {...},
-  "publishedAt": 1339761600000,
-  "addedAt": 1667326679503,
-  "updatedAt": 1667326679503,
-  "duration": 1454.18449,
-  "size": 23653735
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`libraryItemId` | String | The ID of the library item that contains the podcast.
-`id` | String | The ID of the podcast episode.
-`index` | Integer | The index of the podcast episode.
-`season` | String | The season of the podcast episode, if known.
-`episode` | String | The episode of the season of the podcast, if known.
-`episodeType` | String | The type of episode that the podcast episode is.
-`title` | String | The title of the podcast episode.
-`subtitle` | String | The subtitle of the podcast episode.
-`description` | String | A HTML encoded, description of the podcast episode.
-`enclosure` | [Podcast Episode Enclosure](#podcast-episode-enclosure) Object | Information about the podcast episode from when it was downloaded.
-`pubDate` | String | When the podcast episode was published.
-`audioFile` | [Audio File](#audio-file) Object | The audio file for the podcast episode.
-`publishedAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode was published.
-`addedAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode was added to the library.
-`updatedAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode was last updated.
-
-### Podcast Episode Expanded
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`audioTrack` | [Audio Track](#audio-track) Object | The podcast episode's audio tracks from the audio file.
-`duration` | Float | The total length (in seconds) of the podcast episode.
-`size` | Integer | The total size (in bytes) of the podcast episode.
-
-
-## Podcast Episode Enclosure
-
-> Podcast Episode Enclosure
-
-```json
-{
-  "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
-  "type": "audio/mpeg",
-  "length": "20588611"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`url` | String | The URL where the podcast episode's audio file was downloaded from.
-`type` | String | The MIME type of the podcast episode's audio file.
-`length` | String | The size (in bytes) that was reported when downloading the podcast episode's audio file.
-
-
-## Podcast Episode Download
-
-> Podcast Episode Download
-
-```json
-{
-  "id": "epdl_pgv4d47j6dtqpk4r0v",
-  "episodeDisplayTitle": "2 - Glow Cloud",
-  "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/cb1dd91f-5d8d-42e9-ba22-14ff335d2cbb/2_Glow_Cloud.mp3",
-  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-  "libraryId": "lib_p9wkw2i85qy9oltijt",
-  "isFinished": false,
-  "failed": false,
-  "startedAt": null,
-  "createdAt": 1668122813409,
-  "finishedAt": null,
-  "podcastTitle": "Welcome to Night Vale",
-  "podcastExplicit": false,
-  "season": "",
-  "episode": "",
-  "episodeType": "full",
-  "publishedAt": 1341144000000
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the podcast episode download.
-`episodeDisplayTitle` | String | The display title of the episode to be downloaded.
-`url` | String | The URL from which to download the episode.
-`libraryItemId` | String | The ID of the library item the episode belongs to.
-`libraryId` | String | The ID of the library the episode's podcast belongs to.
-`isFinished` | Boolean | Whether the episode has finished downloading.
-`failed` | Boolean | Whether the episode failed to download.
-`startedAt` | Integer or null | The time (in ms since POSIX epoch) when the episode started downloading. Will be `null` if it has not started downloading yet.
-`createdAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode download request was created.
-`finishedAt` | Integer or null | The time (in ms since POSIX epoch) when the episode finished downloading. Will be `null` if it has not finished.
-`podcastTitle` | String or null | The title of the episode's podcast.
-`podcastExplicit` | Boolean | Whether the episode's podcast is explicit.
-`season` | String or null | The season of the podcast episode.
-`episode` | String or null | The episode number of the podcast episode.
-`episodeType` | String | The type of the podcast episode.
-`publishedAt` | Integer or null | The time (in ms since POSIX epoch) when the episode was published.
-
-
-## Podcast Feed
-
-> Podcast Feed
-
-```json
-{
-  "metadata": {...},
-  "episodes": [...]
-}
-```
-
-> Podcast Feed Minified
-
-```json
-{
-  "metadata": {...},
-  "numEpisodes": 280
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`metadata` | [Podcast Feed Metadata](#podcast-feed-metadata) Object | The podcast's metadata from the feed.
-`episodes` | Array of [Podcast Feed Episode](#podcast-feed-episode) | The podcast's episodes from the feed.
-
-### Podcast Feed Minified
-
-#### Removed Attributes
-
-* `episodes`
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`numEpisodes` | Integer | The number of episodes the podcast has.
-
-
-## Podcast Feed Metadata
-
-> Podcast Feed Metadata
-
-```json
-{
-  "image": "https://f.prxu.org/126/images/1f749c5d-c83a-4db9-8112-a3245da49c54/nightvalelogo-web4.jpg",
-  "categories": [
-    "Fiction:Science Fiction"
-  ],
-  "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
-  "description": "\n      <p>Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.</p>\n    ",
-  "descriptionPlain": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-  "title": "Welcome to Night Vale",
-  "language": "en",
-  "explicit": "false",
-  "author": "Night Vale Presents",
-  "pubDate": "Thu, 17 Nov 2022 16:04:42 -0000",
-  "link": "http://welcometonightvale.com"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`image` | String | A URL for the podcast's cover image.
-`categories` | Array of String | The podcast's categories. Can be similar to genres.
-`feedUrl` | String | A URL of an RSS feed for the podcast.
-`description` | String | A HTML encoded description of the podcast.
-`descriptionPlain` | String | A plain text description of the podcast.
-`title` | String | The podcast's title.
-`language` | String | The podcast's language.
-`explicit` | String | Whether the podcast is explicit. Will probably be `"true"` or `"false"`.
-`author` | String | The podcast's author.
-`pubDate` | String | The podcast's publication date.
-`link` | String | A URL the RSS feed provided for possible display to the user.
-
-
-## Podcast Feed Episode
-
-> Podcast Feed Episode
-
-```json
-{
-  "title": "1 - Pilot",
-  "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
-  "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
-  "descriptionPlain": "\n        Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.\n\nWeather: \"These and More Than These\" by Joseph Fink\n\nMusic: Disparition, disparition.info\n\nLogo: Rob Wilson, silastom.com\n\nProduced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.\n      ",
-  "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
-  "episodeType": "full",
-  "season": "",
-  "episode": "",
-  "author": "",
-  "duration": "21:02",
-  "explicit": "",
-  "publishedAt": 1339761600000,
-  "enclosure": {...}
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`title` | String | The podcast episode's title.
-`subtitle` | String | The podcast episode's subtitle.
-`description` | String | A HTML encoded description of the podcast episode.
-`descriptionPlain` | String | A plain text description of the podcast episode.
-`pubDate` | String | The podcast episode's publication date.
-`episodeType` | String | The type of episode that the podcast episode is.
-`season` | String | The season of the podcast episode.
-`episode` | String | The episode of the season of the podcast.
-`author` | String | The author of the podcast episode.
-`duration` | String | The duration of the podcast episode as reported by the RSS feed.
-`explicit` | String | Whether the podcast episode is explicit.
-`publishedAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode was published.
-`enclosure` | [Podcast Episode Enclosure](#podcast-episode-enclosure) Object | Download information for the podcast episode.
-
-
-## Audio File
-
-> Audio File
-
-```json
-{
-  "index": 1,
-  "ino": "649644248522215260",
-  "metadata": {...},
-  "addedAt": 1650621074131,
-  "updatedAt": 1651830828023,
-  "trackNumFromMeta": 1,
-  "discNumFromMeta": null,
-  "trackNumFromFilename": 1,
-  "discNumFromFilename": null,
-  "manuallyVerified": false,
-  "invalid": false,
-  "exclude": false,
-  "error": null,
-  "format": "MP2/3 (MPEG audio layer 2/3)",
-  "duration": 6004.6675,
-  "bitRate": 64000,
-  "language": null,
-  "codec": "mp3",
-  "timeBase": "1/14112000",
-  "channels": 2,
-  "channelLayout": "stereo",
-  "chapters": [],
-  "embeddedCoverArt": null,
-  "metaTags": {...},
-  "mimeType": "audio/mpeg"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`index` | Integer | The index of the audio file.
-`ino` | String | The inode of the audio file.
-`metadata` | [File Metadata](#file-metadata) Object | The audio file's metadata.
-`addedAt` | Integer | The time (in ms since POSIX epoch) when the audio file was added to the library.
-`updatedAt` | Integer | The time (in ms since POSIX epoch) when the audio file last updated. (Read Only)
-`trackNumFromMeta` | Integer or null | The track number of the audio file as pulled from the file's metadata. Will be `null` if unknown.
-`discNumFromMeta` | Integer or null | The disc number of the audio file as pulled from the file's metadata. Will be `null` if unknown.
-`trackNumFromFilename` | Integer or null | The track number of the audio file as determined from the file's name. Will be `null` if unknown.
-`discNumFromFilename` | Integer or null | The track number of the audio file as determined from the file's name. Will be `null` if unknown.
-`manuallyVerified` | Boolean | Whether the audio file has been manually verified by a user.
-`invalid` | Boolean | Whether the audio file is missing from the server.
-`exclude` | Boolean | Whether the audio file has been marked for exclusion.
-`error` | String or null | Any error with the audio file. Will be `null` if there is none.
-`format` | String | The format of the audio file.
-`duration` | Float | The total length (in seconds) of the audio file.
-`bitRate` | Integer | The bit rate (in bit/s) of the audio file.
-`language` | String or null | The language of the audio file.
-`codec` | String | The codec of the audio file.
-`timeBase` | String | The time base of the audio file.
-`channels` | Integer | The number of channels the audio file has.
-`channelLayout` | String | The layout of the audio file's channels.
-`chapters` | Array of [Book Chapter](#book-chapter) | If the audio file is part of an audiobook, the chapters the file contains.
-`embeddedCoverArt` | String or null | The type of embedded cover art in the audio file. Will be `null` if none exists.
-`metaTags` | [Audio Meta Tags](#audio-meta-tags) Object | The audio metadata tags from the audio file.
-`mimeType` | String | The MIME type of the audio file.
-
-
-## Audio Meta Tags
-
-> Audio Meta Tags
-
-```json
-{
-  "tagAlbum": "SOT Bk01",
-  "tagArtist": "Terry Goodkind",
-  "tagGenre": "Audiobook Fantasy",
-  "tagTitle": "Wizards First Rule 01",
-  "tagSeries": null,
-  "tagSeriesPart": null,
-  "tagTrack": "01/20",
-  "tagDisc": null,
-  "tagSubtitle": null,
-  "tagAlbumArtist": "Terry Goodkind",
-  "tagDate": null,
-  "tagComposer": "Terry Goodkind",
-  "tagPublisher": null,
-  "tagComment": null,
-  "tagDescription": null,
-  "tagEncoder": null,
-  "tagEncodedBy": null,
-  "tagIsbn": null,
-  "tagLanguage": null,
-  "tagASIN": null,
-  "tagOverdriveMediaMarker": null,
-  "tagOriginalYear": null,
-  "tagReleaseCountry": null,
-  "tagReleaseType": null,
-  "tagReleaseStatus": null,
-  "tagISRC": null,
-  "tagMusicBrainzTrackId": null,
-  "tagMusicBrainzAlbumId": null,
-  "tagMusicBrainzAlbumArtistId": null,
-  "tagMusicBrainzArtistId": null
-}
-```
-
-[ID3](https://en.wikipedia.org/wiki/ID3) metadata tags pulled from the audio file on import.
-Only non-null tags will be returned in requests.
-
-
-## Audio Track
-
-> Audio Track
-
-```json
-{
-  "index": 1,
-  "startOffset": 0,
-  "duration": 33854.905,
-  "title": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-  "contentUrl": "/s/item/li_8gch9ve09orgn4fdz8/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-  "mimeType": "audio/mpeg",
-  "metadata": {...}
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`index` | Integer | The index of the audio track.
-`startOffset` | Float | When in the audio file (in seconds) the track starts.
-`duration` | Float | The length (in seconds) of the audio track.
-`title` | String | The filename of the audio file the audio track belongs to.
-`contentUrl` | String | The URL path of the audio file.
-`mimeType` | String | The MIME type of the audio file.
-`metadata` | [File Metadata](#file-metadata) Object or null | The metadata of the audio file.
-
-
-## EBook File
-
-> EBook File
-
-```json
-{
-  "ino" : "9463162",
-  "metadata": {...},
-  "ebookFormat": "epub",
-  "addedAt": 1650621073750,
-  "updatedAt": 1650621110769
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`ino` | String | The inode of the ebook file.
-`metadata` | [File Metadata](#file-metadata) Object | The metadata of the ebook file.
-`ebookFormat` | String | The ebook format of the ebook file.
-`addedAt` | Integer | The time (in ms since POSIX epoch) when the library file was added.
-`updatedAt` | Integer | The time (in ms since POSIX epoch) when the library file was last updated.
-
-
-## Library File
-
-> Library File
-
-```json
-{
-  "ino": "649644248522215260",
-  "metadata": {...},
-  "addedAt": 1650621052494,
-  "updatedAt": 1650621052494,
-  "fileType": "audio"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`ino` | String | The inode of the library file.
-`metadata` | [File Metadata](#file-metadata) Object | The metadata for the library file.
-`addedAt` | Integer | The time (in ms since POSIX epoch) when the library file was added.
-`updatedAt` | Integer | The time (in ms since POSIX epoch) when the library file was last updated.
-`fileType` | String | The type of file that the library file is (audio, image, etc.).
-
-
-## File Metadata
-
-> File Metadata
-
-```json
-{
-  "filename": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-  "ext": ".mp3",
-  "path": "/audiobooks/Terry Goodkind/Sword of Truth/Wizards First Rule/Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-  "relPath": "Terry Goodkind - SOT Bk01 - Wizards First Rule 01.mp3",
-  "size": 48037888,
-  "mtimeMs": 1632223180278,
-  "ctimeMs": 1645978261001,
-  "birthtimeMs": 0
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`filename` | String | The filename of the file.
-`ext` | String | The file extension of the file.
-`path` | String | The absolute path on the server of the file.
-`relPath` | String | The path of the file, relative to the book's or podcast's folder.
-`size` | Integer | The size (in bytes) of the file.
-`mtimeMs` | Integer | The time (in ms since POSIX epoch) when the file was last modified on disk.
-`ctimeMs` | Integer | The time (in ms since POSIX epoch) when the file status was changed on disk.
-`birthtimeMs` | Integer | The time (in ms since POSIX epoch) when the file was created on disk. Will be `0` if unknown.
-
-
-## Author
-
-> Author
-
-```json
-{
-  "id": "aut_z3leimgybl7uf3y4ab",
-  "asin": null,
-  "name": "Terry Goodkind",
-  "description": null,
-  "imagePath": null,
-  "addedAt": 1650621073750,
-  "updatedAt": 1650621073750
-}
-```
-
-> Author Minified
-
-```json
-{
-  "id": "aut_z3leimgybl7uf3y4ab",
-  "name": "Terry Goodkind"
-}
-```
-
-> Author Expanded
-
-```json
-{
-  "id": "aut_z3leimgybl7uf3y4ab",
-  "asin": null,
-  "name": "Terry Goodkind",
-  "description": null,
-  "imagePath": null,
-  "addedAt": 1650621073750,
-  "updatedAt": 1650621073750,
-  "numBooks": 1
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the author.
-`asin` | String or null | The ASIN of the author. Will be `null` if unknown.
-`name` | String | The name of the author.
-`description` | String or null | A description of the author. Will be `null` if there is none.
-`imagePath` | String or null | The absolute path for the author image. Will be `null` if there is no image.
-`addedAt` | Integer | The time (in ms since POSIX epoch) when the author was added.
-`updatedAt` | Integer | The time (in ms since POSIX epoch) when the author was last updated.
-
-### Author Minified
-
-#### Removed Attributes
-
-* `asin`
-* `description`
-* `imagePath`
-* `addedAt`
-* `updatedAt`
-
-### Author Expanded
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`numBooks` | Integer | The number of books associated with the author in the library.
-
-
-## Series
-
-> Series
-
-```json
-{
-  "id": "ser_cabkj4jeu8be3rap4g",
-  "name": "Sword of Truth",
-  "description": null,
-  "addedAt": 1650621073750,
-  "updatedAt": 1650621073750
-}
-```
-
-> Series Num Books
-
-```json
-{
-  "id": "ser_cabkj4jeu8be3rap4g",
-  "name": "Sword of Truth",
-  "nameIgnorePrefix": "Sword of Truth",
-  "libraryItemIds": [
-    "li_8gch9ve09orgn4fdz8"
-  ],
-  "numBooks": 1
-}
-```
-
-> Series Books
-
-```json
-{
-  "id": "ser_cabkj4jeu8be3rap4g",
-  "name": "Sword of Truth",
-  "nameIgnorePrefix": "Sword of Truth",
-  "nameIgnorePrefixSort": "Sword of Truth",
-  "type": "series",
-  "books": [...],
-  "addedAt": 1650621073750,
-  "totalDuration": 12000.946
-}
-```
-
-> Series Sequence
-
-```json
-{
-  "id": "ser_cabkj4jeu8be3rap4g",
-  "name": "Sword of Truth",
-  "sequence": "1"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the series.
-`name` | String | The name of the series.
-`description` | String or null | A description for the series. Will be `null` if there is none.
-`addedAt` | Integer | The time (in ms since POSIX epoch) when the series was added.
-`updatedAt` | Integer | The time (in ms since POSIX epoch) when the series was last updated.
-
-### Series Num Books
-
-#### Removed Attributes
-
-* `description`
-* `addedAt`
-* `updatedAt`
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`nameIgnorePrefix` | String | The name of the series with any prefix moved to the end.
-`libraryItemIds` | Array of String | The IDs of the library items in the series.
-`numBooks` | Integer | The number of books in the series.
-
-### Series Books
-
-#### Removed Attributes
-
-* `description`
-* `updatedAt`
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`nameIgnorePrefix` | String | The name of the series with any prefix moved to the end.
-`nameIgnorePrefixSort` | String | The name of the series with any prefix removed.
-`type` | String | Will always be `series`.
-`books` | Array of [Library Item](#library-item) | The library items that contain the books in the series. A `sequence` attribute that denotes the position in the series the book is in, is tacked on.
-`totalDuration` | Float | The combined duration (in seconds) of all books in the series.
-
-### Series Sequence
-
-#### Removed Attributes
-
-* `description`
-* `addedAt`
-* `updatedAt`
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`sequence` | String or null | The position in the series the book is.
-
-
-## Collection
-
-> Collection
-
-```json
-{
-  "id": "col_fpfstanv6gd7tq2qz7",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "Favorites",
-  "description": null,
-  "cover": null,
-  "coverFullPath": null,
-  "books": [...],
-  "lastUpdate": 1650621110769,
-  "createdAt": 1650621073750
-}
-```
-
-> Collection Expanded
-
-```json
-{
-  "id": "col_fpfstanv6gd7tq2qz7",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "Favorites",
-  "description": null,
-  "cover": null,
-  "coverFullPath": null,
-  "books": [...],
-  "lastUpdate": 1650621110769,
-  "createdAt": 1650621073750
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the collection.
-`libraryId` | String | The ID of the library the collection belongs to.
-`userId` | String | The ID of the user that created the collection.
-`name` | String | The name of the collection.
-`description` | String or null | The collection's description. Will be `null` if there is none.
-`cover` | String or null | The path to the collection's cover. Will be `null` if there is no cover.
-`coverFullPath` | String or null | The full path to collection's cover. Will be `null` if there is no cover.
-`books` | Array of [Library Item](#library-item) | The books that belong to the collection.
-`lastUpdate` | Integer | The time (in ms since POSIX epoch) when the collection was last updated.
-`createdAt` | Integer | The time (in ms since POSIX epoch) when the collection was created.
-
-### Collection Expanded
-
-#### Modified Attributes
-
-* `books` is an Array of [Library Item Expanded](#library-item-expanded).
-
-
-## Playlist
-
-> Playlist
-
-```json
-{
-  "id": "pl_qbwet64998s5ra6dcu",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "Favorites",
-  "description": null,
-  "coverPath": null,
-  "items": [...],
-  "lastUpdate": 1669623431313,
-  "createdAt": 1669623431313
-}
-```
-
-> Playlist Expanded
-
-```json
-{
-  "id": "pl_qbwet64998s5ra6dcu",
-  "libraryId": "lib_c1u6t4p45c35rf0nzd",
-  "userId": "root",
-  "name": "Favorites",
-  "description": null,
-  "coverPath": null,
-  "items": [...],
-  "lastUpdate": 1669623431313,
-  "createdAt": 1669623431313
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the playlist.
-`libraryId` | String | The ID of the library the playlist belongs to.
-`userId` | String | The ID of the user the playlist belongs to.
-`name` | String | The playlist's name.
-`description` | String or null | The playlist's description.
-`coverPath` | String or null | The path of the playlist's cover.
-`items` | Array of [Playlist Item](#playlist-item) | The items in the playlist.
-`lastUpdate` | Integer | The time (in ms since POSIX epoch) when the playlist was last updated.
-`createdAt` | Integer | The time (in ms since POSIX epoch) when the playlist was created.
-
-### Playlist Expanded
-
-#### Modified Attributes
-
-* `items` is an Array of [Playlist Item Expanded](#playlist-item-expanded).
-
-
-## Playlist Item
-
-> Playlist Item
-
-```json
-{
-  "libraryItemId": "li_8gch9ve09orgn4fdz8",
-  "episodeId": null
-}
-```
-
-> Playlist Item Expanded
-
-```json
-{
-  "libraryItemId": "li_8gch9ve09orgn4fdz8",
-  "episodeId": null,
-  "libraryItem": {...}
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`libraryItemId` | String | The ID of the library item the playlist item is for.
-`episodeId` | String or null | The ID of the podcast episode the playlist item is for.
-
-### Playlist Item Expanded
-
-#### Added Attributes
-
-Attribute | Type | Description
---------- | ---- | -----------
-`episode` | [Podcast Episode Expanded](#podcast-episode-expanded) Object | The podcast episode the playlist item is for. Will only exist if `episodeId` is not `null`.
-`libraryItem` | [Library Item Expanded](#library-item-expanded) or [Library Item Minified](#library-item-minified) Object | The library item the playlist item is for. Will be [Library Item Minified](#library-item-minified) if `episodeId` is not `null`.
+`coverAspectRatio` | Integer | Whether the library should use square book covers. Must be `0` (for false) or `1` (for true).
+`disableWatcher` | Boolean | Whether to disable the folder watcher for the library.
+`skipMatchingMediaWithAsin` | Boolean | Whether to skip matching books that already have an ASIN.
+`skipMatchingMediaWithIsbn` | Boolean | Whether to skip matching books that already have an ISBN.
+`autoScanCronExpression` | String or null | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to automatically scan the library folders. If `null`, automatic scanning will be disabled.
 
 
 ## Media Progress
@@ -1580,6 +1001,127 @@ Attribute | Type | Description
 --------- | ---- | -----------
 `media` | [Book Expanded](#book-expanded) or [Podcast Expanded](#podcast-expanded) Object | The media of the library item the media progress is for.
 `episode` | [Podcast Episode](#podcast-episode) | The podcast episode the media progress is for. Will only exist if the media progress is for a podcast episode.
+
+
+## Notification
+
+> Notification
+
+```json
+{
+  "id": "noti_nod281qwkj5ow7h7fi",
+  "libraryId": null,
+  "eventName": "onPodcastEpisodeDownloaded",
+  "urls": [
+    "apprises://apprise.example.com/email"
+  ],
+  "titleTemplate": "New {{podcastTitle}} Episode!",
+  "bodyTemplate": "{{episodeTitle}} has been added to {{libraryName}} library.",
+  "enabled": true,
+  "type": "info",
+  "lastFiredAt": 1668776410792,
+  "lastAttemptFailed": false,
+  "numConsecutiveFailedAttempts": 0,
+  "numTimesFired": 5,
+  "createdAt": 1666545142424
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the notification.
+`libraryId` | String or null | The ID of the library the notification is associated with.
+`eventName` | String | The name of the event the notification will fire on.
+`urls` | Array of String | The Apprise URLs to use for the notification.
+`titleTemplate` | String | The template for the notification title.
+`bodyTemplate` | String | The template for the notification body.
+`enabled` | Boolean | Whether the notification is enabled.
+`type` | String | The notification's type.
+`lastFiredAt` | Integer or null | The time (in ms since POSIX epoch) when the notification was last fired. Will be `null` if the notification has not fired.
+`lastAttemptFailed` | Boolean | Whether the last notification attempt failed.
+`numConsecutiveFailedAttempts` | Integer | The number of consecutive times the notification has failed.
+`numTimesFired` | Integer | The number of times the notification has fired.
+`createdAt` | Integer | The time (in ms since POSIX epoch) when the notification was created.
+
+
+## Notification Event
+
+> Notification Event
+
+```json
+{
+  "name": "onPodcastEpisodeDownloaded",
+  "requiresLibrary": true,
+  "libraryMediaType": "podcast",
+  "description": "Triggered when a podcast episode is auto-downloaded",
+  "variables": [
+    "libraryItemId",
+    "libraryId",
+    "libraryName",
+    "mediaTags",
+    "podcastTitle",
+    "podcastAuthor",
+    "podcastDescription",
+    "podcastGenres",
+    "episodeId",
+    "episodeTitle",
+    "episodeSubtitle",
+    "episodeDescription"
+  ],
+  "defaults": {
+    "title": "New {{podcastTitle}} Episode!",
+    "body": "{{episodeTitle}} has been added to {{libraryName}} library."
+  },
+  "testData": {
+    "libraryItemId": "li_notification_test",
+    "libraryId": "lib_test",
+    "libraryName": "Podcasts",
+    "podcastTitle": "Abs Test Podcast",
+    "episodeId": "ep_notification_test",
+    "episodeTitle": "Successful Test"
+  }
+}
+```
+
+The notification events that are available are [predefined here](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/notifications.js).
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`name` | String | The name of the notification event.
+`requiresLibrary` | Boolean | Whether the notification event depends on a library existing.
+`libraryMediaType` | String | The type of media of the library the notification depends on existing. Will not exist if `requiresLibrary` is `false`.
+`description` | String | The description of the notification event.
+`variables` | Array of String | The variables of the notification event that can be used in the notification templates.
+`defaults.title` | String | The default title template for notifications using the notification event.
+`defaults.body` | String | The default body template for notifications using the notification event.
+`testData` | Object | The keys of the `testData` object will match the list of `variables`. The values will be the data used when sending a test notification.
+
+
+## Notification Settings
+
+> Notification Settings
+
+```json
+{
+  "id": "notification-settings",
+  "appriseType": "api",
+  "appriseApiUrl": "https://apprise.example.com/notify",
+  "notifications": [...],
+  "maxFailedAttempts": 5,
+  "maxNotificationQueue": 20,
+  "notificationDelay": 1000
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the notification settings.
+`appriseType` | String | The type of Apprise that will be used. At the moment, only `api` is available.
+`appriseApiUrl` | String or null | The full URL where the Apprise API to use is located.
+`notifications` | Array of [Notification](#notification) | The set notifications.
+`maxFailedAttempts` | Integer | The maximum number of times a notification fails before being disabled.
+`maxNotificationQueue` | Integer | The maximum number of notifications in the notification queue before events are ignored.
+`notificationDelay` | Integer | The time (in ms) between notification pushes.
 
 
 ## Playback Session
@@ -1691,40 +1233,986 @@ Attribute | Type | Description
 `libraryItem` | [Library Item Expanded](#library-item-expanded) Object | The library item of the playback session.
 
 
-## Device Info
+## Playlist
 
-> Device Info
+> Playlist
 
 ```json
 {
-  "ipAddress": "192.168.1.118",
-  "browserName": "Firefox",
-  "browserVersion": "106.0",
-  "osName": "Linux",
-  "osVersion": "x86_64",
-  "deviceType": null,
-  "manufacturer": null,
-  "model": null,
-  "sdkVersion": null,
-  "serverVersion": "2.2.2"
+  "id": "pl_qbwet64998s5ra6dcu",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "Favorites",
+  "description": null,
+  "coverPath": null,
+  "items": [...],
+  "lastUpdate": 1669623431313,
+  "createdAt": 1669623431313
 }
 ```
 
-Any attributes with a `null` value will be filtered out in responses.
+> Playlist Expanded
+
+```json
+{
+  "id": "pl_qbwet64998s5ra6dcu",
+  "libraryId": "lib_c1u6t4p45c35rf0nzd",
+  "userId": "root",
+  "name": "Favorites",
+  "description": null,
+  "coverPath": null,
+  "items": [...],
+  "lastUpdate": 1669623431313,
+  "createdAt": 1669623431313
+}
+```
 
 Attribute | Type | Description
 --------- | ---- | -----------
-`ipAddress` | String or null | The IP address that the request came from.
-`browserName` | String or null | The browser name, taken from the user agent.
-`browserVersion` | String or null | The browser version, taken from the user agent.
-`osName` | String or null | The name of OS, taken from the user agent.
-`osVersion` | String or null | The version of the OS, taken from the user agent.
-`deviceType` | String or null | The device type, taken from the user agent.
-`manufacturer` | String or null | The client device's manufacturer, as provided in the request.
-`model` | String or null | The client device's model, as provided in the request.
-`sdkVersion` | Integer or null | For an Android device, the Android SDK version of the client, as provided in the request.
-`serverVersion` | String or null | The version of the server at the time of the request.
+`id` | String | The ID of the playlist.
+`libraryId` | String | The ID of the library the playlist belongs to.
+`userId` | String | The ID of the user the playlist belongs to.
+`name` | String | The playlist's name.
+`description` | String or null | The playlist's description.
+`coverPath` | String or null | The path of the playlist's cover.
+`items` | Array of [Playlist Item](#playlist-item) | The items in the playlist.
+`lastUpdate` | Integer | The time (in ms since POSIX epoch) when the playlist was last updated.
+`createdAt` | Integer | The time (in ms since POSIX epoch) when the playlist was created.
 
+### Playlist Expanded
+
+#### Modified Attributes
+
+* `items` is an Array of [Playlist Item Expanded](#playlist-item-expanded).
+
+
+## Playlist Item
+
+> Playlist Item
+
+```json
+{
+  "libraryItemId": "li_8gch9ve09orgn4fdz8",
+  "episodeId": null
+}
+```
+
+> Playlist Item Expanded
+
+```json
+{
+  "libraryItemId": "li_8gch9ve09orgn4fdz8",
+  "episodeId": null,
+  "libraryItem": {...}
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`libraryItemId` | String | The ID of the library item the playlist item is for.
+`episodeId` | String or null | The ID of the podcast episode the playlist item is for.
+
+### Playlist Item Expanded
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`episode` | [Podcast Episode Expanded](#podcast-episode-expanded) Object | The podcast episode the playlist item is for. Will only exist if `episodeId` is not `null`.
+`libraryItem` | [Library Item Expanded](#library-item-expanded) or [Library Item Minified](#library-item-minified) Object | The library item the playlist item is for. Will be [Library Item Minified](#library-item-minified) if `episodeId` is not `null`.
+
+
+## Podcast
+
+> Podcast
+
+```json
+{
+  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+  "metadata": {...},
+  "coverPath": "/podcasts/Welcome to Night Vale/cover.jpg",
+  "tags": [
+    "Favorite"
+  ],
+  "episodes": [...],
+  "autoDownloadEpisodes": true,
+  "autoDownloadSchedule": "0 0 * * 1",
+  "lastEpisodeCheck": 1667326662087,
+  "maxEpisodesToKeep": 0,
+  "maxNewEpisodesToDownload": 3
+}
+```
+
+> Podcast Minified
+
+```json
+{
+  "metadata": {...},
+  "coverPath": "/podcasts/Welcome to Night Vale/cover.jpg",
+  "tags": [
+    "Favorite"
+  ],
+  "numEpisodes": 1,
+  "autoDownloadEpisodes": true,
+  "autoDownloadSchedule": "0 0 * * 1",
+  "lastEpisodeCheck": 1667326662087,
+  "maxEpisodesToKeep": 0,
+  "maxNewEpisodesToDownload": 3,
+  "size": 23706728
+}
+```
+
+> Podcast Expanded
+
+```json
+{
+  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+  "metadata": {...},
+  "coverPath": "/podcasts/Welcome to Night Vale/cover.jpg",
+  "tags": [
+    "Favorite"
+  ],
+  "episodes": [...],
+  "autoDownloadEpisodes": true,
+  "autoDownloadSchedule": "0 0 * * 1",
+  "lastEpisodeCheck": 1667326662087,
+  "maxEpisodesToKeep": 0,
+  "maxNewEpisodesToDownload": 3,
+  "size": 23706728
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`libraryItemId` | String | The ID of the library item that contains the podcast.
+`metadata` | [Podcast Metadata](#podcast-metadata) Object | The metadata for the podcast.
+`coverPath` | String or null | The absolute path on the server of the cover file. Will be `null` if there is no cover.
+`tags` | Array of String | The podcast's tags.
+`episodes` | Array of [Podcast Episode](#podcast-episode) | The downloaded episodes of the podcast.
+`autoDownloadEpisodes` | Boolean | Whether the server will automatically download podcast episodes according to the schedule.
+`autoDownloadSchedule` | String | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to automatically download podcast episodes. Will not exist if `autoDownloadEpisodes` is `false`.
+`lastEpisodeCheck` | Integer | The time (in ms since POSIX epoch) when the podcast was checked for new episodes.
+`maxEpisodesToKeep` | Integer | The maximum number of podcast episodes to keep when automatically downloading new episodes. Episodes beyond this limit will be deleted. If `0`, all episodes will be kept.
+`maxNewEpisodesToDownload` | Integer | The maximum number of podcast episodes to download when automatically downloading new episodes. If `0`, all episodes will be downloaded.
+
+### Podcast Minified
+
+#### Removed Attributes
+
+* `libraryItemId`
+* `episodes`
+
+#### Modified Attributes
+
+* `metadata` is [Podcast Metadata Minified](#podcast-metadata-minified)
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`numEpisodes` | Integer | The number of downloaded episodes for the podcast.
+`size` | Integer | The total size (in bytes) of the podcast.
+
+### Podcast Expanded
+
+#### Modified Attributes
+
+* `metadata` is [Podcast Metadata Expanded](#podcast-metadata-expanded)
+* `episodes` is an Array of [Podcast Episodes Expanded](#podcast-episode-expanded)
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`size` | Integer | The total size (in bytes) of the podcast.
+
+
+## Podcast Episode
+
+> Podcast Episode
+
+```json
+{
+  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+  "id": "ep_lh6ko39pumnrma3dhv",
+  "index": 1,
+  "season": "",
+  "episode": "",
+  "episodeType": "full",
+  "title": "1 - Pilot",
+  "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
+  "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
+  "enclosure": {...},
+  "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
+  "audioFile": {...},
+  "publishedAt": 1339761600000,
+  "addedAt": 1667326679503,
+  "updatedAt": 1667326679503
+}
+```
+
+> Podcast Episode Expanded
+
+```json
+{
+  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+  "id": "ep_lh6ko39pumnrma3dhv",
+  "index": 1,
+  "season": "",
+  "episode": "",
+  "episodeType": "full",
+  "title": "1 - Pilot",
+  "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
+  "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
+  "enclosure": {...},
+  "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
+  "audioFile": {...},
+  "audioTrack": {...},
+  "publishedAt": 1339761600000,
+  "addedAt": 1667326679503,
+  "updatedAt": 1667326679503,
+  "duration": 1454.18449,
+  "size": 23653735
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`libraryItemId` | String | The ID of the library item that contains the podcast.
+`id` | String | The ID of the podcast episode.
+`index` | Integer | The index of the podcast episode.
+`season` | String | The season of the podcast episode, if known.
+`episode` | String | The episode of the season of the podcast, if known.
+`episodeType` | String | The type of episode that the podcast episode is.
+`title` | String | The title of the podcast episode.
+`subtitle` | String | The subtitle of the podcast episode.
+`description` | String | A HTML encoded, description of the podcast episode.
+`enclosure` | [Podcast Episode Enclosure](#podcast-episode-enclosure) Object | Information about the podcast episode from when it was downloaded.
+`pubDate` | String | When the podcast episode was published.
+`audioFile` | [Audio File](#audio-file) Object | The audio file for the podcast episode.
+`publishedAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode was published.
+`addedAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode was added to the library.
+`updatedAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode was last updated.
+
+### Podcast Episode Expanded
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`audioTrack` | [Audio Track](#audio-track) Object | The podcast episode's audio tracks from the audio file.
+`duration` | Float | The total length (in seconds) of the podcast episode.
+`size` | Integer | The total size (in bytes) of the podcast episode.
+
+
+## Podcast Episode Download
+
+> Podcast Episode Download
+
+```json
+{
+  "id": "epdl_pgv4d47j6dtqpk4r0v",
+  "episodeDisplayTitle": "2 - Glow Cloud",
+  "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/cb1dd91f-5d8d-42e9-ba22-14ff335d2cbb/2_Glow_Cloud.mp3",
+  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+  "libraryId": "lib_p9wkw2i85qy9oltijt",
+  "isFinished": false,
+  "failed": false,
+  "startedAt": null,
+  "createdAt": 1668122813409,
+  "finishedAt": null,
+  "podcastTitle": "Welcome to Night Vale",
+  "podcastExplicit": false,
+  "season": "",
+  "episode": "",
+  "episodeType": "full",
+  "publishedAt": 1341144000000
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the podcast episode download.
+`episodeDisplayTitle` | String | The display title of the episode to be downloaded.
+`url` | String | The URL from which to download the episode.
+`libraryItemId` | String | The ID of the library item the episode belongs to.
+`libraryId` | String | The ID of the library the episode's podcast belongs to.
+`isFinished` | Boolean | Whether the episode has finished downloading.
+`failed` | Boolean | Whether the episode failed to download.
+`startedAt` | Integer or null | The time (in ms since POSIX epoch) when the episode started downloading. Will be `null` if it has not started downloading yet.
+`createdAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode download request was created.
+`finishedAt` | Integer or null | The time (in ms since POSIX epoch) when the episode finished downloading. Will be `null` if it has not finished.
+`podcastTitle` | String or null | The title of the episode's podcast.
+`podcastExplicit` | Boolean | Whether the episode's podcast is explicit.
+`season` | String or null | The season of the podcast episode.
+`episode` | String or null | The episode number of the podcast episode.
+`episodeType` | String | The type of the podcast episode.
+`publishedAt` | Integer or null | The time (in ms since POSIX epoch) when the episode was published.
+
+
+## Podcast Episode Enclosure
+
+> Podcast Episode Enclosure
+
+```json
+{
+  "url": "https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/1fadf1ad-aad8-449f-843b-6e8bb6949622/1_Pilot.mp3",
+  "type": "audio/mpeg",
+  "length": "20588611"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`url` | String | The URL where the podcast episode's audio file was downloaded from.
+`type` | String | The MIME type of the podcast episode's audio file.
+`length` | String | The size (in bytes) that was reported when downloading the podcast episode's audio file.
+
+
+## Podcast Feed
+
+> Podcast Feed
+
+```json
+{
+  "metadata": {...},
+  "episodes": [...]
+}
+```
+
+> Podcast Feed Minified
+
+```json
+{
+  "metadata": {...},
+  "numEpisodes": 280
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`metadata` | [Podcast Feed Metadata](#podcast-feed-metadata) Object | The podcast's metadata from the feed.
+`episodes` | Array of [Podcast Feed Episode](#podcast-feed-episode) | The podcast's episodes from the feed.
+
+### Podcast Feed Minified
+
+#### Removed Attributes
+
+* `episodes`
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`numEpisodes` | Integer | The number of episodes the podcast has.
+
+
+## Podcast Feed Episode
+
+> Podcast Feed Episode
+
+```json
+{
+  "title": "1 - Pilot",
+  "subtitle": "Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting. Weather: \"These and More Than These\" by Joseph Fink Music:...",
+  "description": "\n        <p>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.</p>\n\n<p>Weather: \"These and More Than These\" by Joseph Fink</p>\n\n<p>Music: Disparition, <a target=\"_blank\">disparition.info</a></p>\n\n<p>Logo: Rob Wilson, <a target=\"_blank\">silastom.com</a></p>\n\n<p>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: <a target=\"_blank\">welcometonightvale.com</a>, and follow <a target=\"_blank\">@NightValeRadio</a> on Twitter or <a target=\"_blank\">Facebook</a>.</p>\n      ",
+  "descriptionPlain": "\n        Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.\n\nWeather: \"These and More Than These\" by Joseph Fink\n\nMusic: Disparition, disparition.info\n\nLogo: Rob Wilson, silastom.com\n\nProduced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.\n      ",
+  "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
+  "episodeType": "full",
+  "season": "",
+  "episode": "",
+  "author": "",
+  "duration": "21:02",
+  "explicit": "",
+  "publishedAt": 1339761600000,
+  "enclosure": {...}
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`title` | String | The podcast episode's title.
+`subtitle` | String | The podcast episode's subtitle.
+`description` | String | A HTML encoded description of the podcast episode.
+`descriptionPlain` | String | A plain text description of the podcast episode.
+`pubDate` | String | The podcast episode's publication date.
+`episodeType` | String | The type of episode that the podcast episode is.
+`season` | String | The season of the podcast episode.
+`episode` | String | The episode of the season of the podcast.
+`author` | String | The author of the podcast episode.
+`duration` | String | The duration of the podcast episode as reported by the RSS feed.
+`explicit` | String | Whether the podcast episode is explicit.
+`publishedAt` | Integer | The time (in ms since POSIX epoch) when the podcast episode was published.
+`enclosure` | [Podcast Episode Enclosure](#podcast-episode-enclosure) Object | Download information for the podcast episode.
+
+
+## Podcast Feed Metadata
+
+> Podcast Feed Metadata
+
+```json
+{
+  "image": "https://f.prxu.org/126/images/1f749c5d-c83a-4db9-8112-a3245da49c54/nightvalelogo-web4.jpg",
+  "categories": [
+    "Fiction:Science Fiction"
+  ],
+  "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
+  "description": "\n      <p>Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.</p>\n    ",
+  "descriptionPlain": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+  "title": "Welcome to Night Vale",
+  "language": "en",
+  "explicit": "false",
+  "author": "Night Vale Presents",
+  "pubDate": "Thu, 17 Nov 2022 16:04:42 -0000",
+  "link": "http://welcometonightvale.com"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`image` | String | A URL for the podcast's cover image.
+`categories` | Array of String | The podcast's categories. Can be similar to genres.
+`feedUrl` | String | A URL of an RSS feed for the podcast.
+`description` | String | A HTML encoded description of the podcast.
+`descriptionPlain` | String | A plain text description of the podcast.
+`title` | String | The podcast's title.
+`language` | String | The podcast's language.
+`explicit` | String | Whether the podcast is explicit. Will probably be `"true"` or `"false"`.
+`author` | String | The podcast's author.
+`pubDate` | String | The podcast's publication date.
+`link` | String | A URL the RSS feed provided for possible display to the user.
+
+
+## Podcast Metadata
+
+> Podcast Metadata
+
+```json
+{
+  "title": "Welcome to Night Vale",
+  "author": "Night Vale Presents",
+  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+  "releaseDate": "2022-10-20T19:00:00Z",
+  "genres": [
+    "Science Fiction",
+    "Podcasts",
+    "Fiction"
+  ],
+  "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
+  "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
+  "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
+  "itunesId": 536258179,
+  "itunesArtistId": 718704794,
+  "explicit": false,
+  "language": null,
+  "type": "episodic"
+}
+```
+
+> Podcast Metadata Minified
+
+```json
+{
+  "title": "Welcome to Night Vale",
+  "titleIgnorePrefix": "Welcome to Night Vale",
+  "author": "Night Vale Presents",
+  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+  "releaseDate": "2022-10-20T19:00:00Z",
+  "genres": [
+    "Science Fiction",
+    "Podcasts",
+    "Fiction"
+  ],
+  "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
+  "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
+  "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
+  "itunesId": 536258179,
+  "itunesArtistId": 718704794,
+  "explicit": false,
+  "language": null,
+  "type": "episodic"
+}
+```
+
+> Podcast Metadata Expanded
+
+```json
+{
+  "title": "Welcome to Night Vale",
+  "titleIgnorePrefix": "Welcome to Night Vale",
+  "author": "Night Vale Presents",
+  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+  "releaseDate": "2022-10-20T19:00:00Z",
+  "genres": [
+    "Science Fiction",
+    "Podcasts",
+    "Fiction"
+  ],
+  "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast",
+  "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg",
+  "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4",
+  "itunesId": 536258179,
+  "itunesArtistId": 718704794,
+  "explicit": false,
+  "language": null,
+  "type": "episodic"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`title` | String or null | The title of the podcast. Will be `null` if unknown.
+`author` | String or null | The author of the podcast. Will be `null` if unknown.
+`description` | String or null | The description for the podcast. Will be `null` if unknown.
+`releaseDate` | String or null | The release date of the podcast. Will be `null` if unknown.
+`genres` | Array of String | The podcast's genres.
+`feedUrl` | String or null | A URL of an RSS feed for the podcast. Will be `null` if unknown.
+`imageUrl` | String or null | A URL of a cover image for the podcast. Will be `null` if unknown.
+`itunesPageUrl` | String or null | A URL of an iTunes page for the podcast. Will be `null` if unknown.
+`itunesId` | Integer or null | The iTunes ID for the podcast. Will be `null` if unknown.
+`itunesArtistId` | Integer or null | The iTunes Artist ID for the author of the podcast. Will be `null` if unknown.
+`explicit` | Boolean | Whether the podcast has been marked as explicit.
+`language` | String or null | The language of the podcast. Will be `null` if unknown.
+`type` | String or null | The type of the podcast.
+
+### Podcast Metadata Minified
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`titleIgnorePrefix` | String | The title of the podcast with any prefix moved to the end.
+
+### Podcast Metadata Expanded
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`titleIgnorePrefix` | String | The title of the podcast with any prefix moved to the end.
+
+
+## RSS Feed
+
+> RSS Feed
+
+```json
+{
+  "id": "li_bufnnmp4y5o2gbbxfm",
+  "slug": "li_bufnnmp4y5o2gbbxfm",
+  "userId": "root",
+  "entityType": "item",
+  "entityId": "li_bufnnmp4y5o2gbbxfm",
+  "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg",
+  "serverAddress": "https://abs.example.com",
+  "feedUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm",
+  "meta": {...},
+  "episodes": [...],
+  "createdAt": 1669031843179,
+  "updatedAt": 1669031843179
+}
+```
+
+> RSS Feed Minified
+
+```json
+{
+  "id": "li_bufnnmp4y5o2gbbxfm",
+  "entityType": "item",
+  "entityId": "li_bufnnmp4y5o2gbbxfm",
+  "feedUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm",
+  "meta": {
+    "title": "Welcome to Night Vale",
+    "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+    "preventIndexing": true,
+    "ownerName": null,
+    "ownerEmail": null
+  }
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the RSS feed.
+`slug` | String | The slug (the last part of the URL) for the RSS feed.
+`userId` | String | The ID of the user that created the RSS feed.
+`entityType` | String | The type of entity the RSS feed is for.
+`entityId` | String | The ID of the entity the RSS feed is for.
+`coverPath` | String | The path of the cover to use for the RSS feed.
+`serverAddress` | String | The server's address.
+`feedUrl` | String | The full URL of the RSS feed.
+`meta` | [RSS Feed Metadata](#rss-feed-metadata) Object | The RSS feed's metadata.
+`episodes` | Array of [RSS Feed Episode](#rss-feed-episode) | The RSS feed's episodes.
+`createdAt` | Integer | The time (in ms since POSIX epoch) when the RSS feed was created.
+`updatedAt` | Integer | The time (in ms since POSIX epoch) when the RSS feed was last updated.
+
+### RSS Feed Minified
+
+#### Removed Attributes
+
+* `slug`
+* `userId`
+* `coverPath`
+* `serverAddress`
+* `episodes`
+* `createdAt`
+* `updatedAt`
+
+#### Modified Attributes
+
+* `meta` is an [RSS Feed Metadata Minified](#rss-feed-metadata-minified)
+
+
+## RSS Feed Episode
+
+> RSS Feed Episode
+
+```json
+{
+  "id": "ep_lh6ko39pumnrma3dhv",
+  "title": "1 - Pilot",
+  "description": "<div><br>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.<br><br></div><div><br>Weather: \"These and More Than These\" by Joseph Fink<br><br></div><div><br>Music: Disparition, disparition.info<br><br></div><div><br>Logo: Rob Wilson, silastom.com<br><br></div><div><br>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.<br><br></div>",
+  "enclosure": {
+    "url": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm/item/ep_lh6ko39pumnrma3dhv/1 - Pilot.mp3",
+    "type": "audio/mpeg",
+    "size": 23653735
+  },
+  "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
+  "link": "https://abs.example.com/item/li_bufnnmp4y5o2gbbxfm",
+  "author": "Night Vale Presents",
+  "explicit": false,
+  "duration": 1454.18449,
+  "season": null,
+  "episode": null,
+  "episodeType": null,
+  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
+  "episodeId": "ep_lh6ko39pumnrma3dhv",
+  "trackIndex": 0,
+  "fullPath": "/podcasts/Welcome to Night Vale/1 - Pilot.mp3"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the RSS feed episode.
+`title` | String | The title of the RSS feed episode.
+`description` | String | An HTML encoded description of the RSS feed episode.
+`enclosure` | Similar to [Podcast Episode Enclosure](#podcast-episode-enclosure) | Download information for the RSS feed episode.
+`pubDate` | String | The RSS feed episode's publication date.
+`link` | String | A URL to display to the RSS feed user.
+`author` | String | The author of the RSS feed episode.
+`explicit` | Boolean | Whether the RSS feed episode is explicit.
+`duration` | Float | The duration (in seconds) of the RSS feed episode.
+`season` | String or null | The season of the RSS feed episode.
+`episode` | String or null | The episode number of the RSS feed episode.
+`episodeType` | String or null | The type of the RSS feed episode.
+`libraryItemId` | String | The ID of the library item the RSS feed is for.
+`episodeId` | String or null | The ID of the podcast episode the RSS feed episode is for. Will be `null` if the RSS feed is for a book.
+`trackIndex` | Integer | The RSS feed episode's track index.
+`fullPath` | String | The path on the server of the audio file the RSS feed episode is for.
+
+
+## RSS Feed Metadata
+
+> RSS Feed Metadata
+
+```json
+{
+  "title": "Welcome to Night Vale",
+  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+  "author": "Night Vale Presents",
+  "imageUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm/cover",
+  "feedUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm",
+  "link": "https://abs.example.com/item/li_bufnnmp4y5o2gbbxfm",
+  "explicit": false,
+  "type": "episodic",
+  "language": "en",
+  "preventIndexing": true,
+  "ownerName": null,
+  "ownerEmail": null
+}
+```
+
+> RSS Feed Metadata Minified
+
+```json
+{
+  "title": "Welcome to Night Vale",
+  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
+  "preventIndexing": true,
+  "ownerName": null,
+  "ownerEmail": null
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`title` | String | The title of the entity the RSS feed is for.
+`description` | String or null | The description of the entity the RSS feed is for.
+`author` | String or null | The author of the entity the RSS feed is for. 
+`imageUrl` | String | The URL of the RSS feed's image.
+`feedUrl` | String | The URL of the RSS feed.
+`link` | String | The URL of the entity the RSS feed is for.
+`explicit` | Boolean | Whether the RSS feed's contents are explicit.
+`type` | String or null | The type of the RSS feed.
+`language` | String or null | The language of the RSS feed.
+`preventIndexing` | Boolean | Whether the RSS feed is marked to prevent indexing of the feed.
+`ownerName` | String or null | The owner name of the RSS feed.
+`ownerEmail` | String or null | The owner email of the RSS feed.
+
+### RSS Feed Metadata Minified
+
+#### Removed Attributes
+
+* `author`
+* `imageUrl`
+* `feedUrl`
+* `link`
+* `explicit`
+* `type`
+* `language`
+
+
+## Series
+
+> Series
+
+```json
+{
+  "id": "ser_cabkj4jeu8be3rap4g",
+  "name": "Sword of Truth",
+  "description": null,
+  "addedAt": 1650621073750,
+  "updatedAt": 1650621073750
+}
+```
+
+> Series Num Books
+
+```json
+{
+  "id": "ser_cabkj4jeu8be3rap4g",
+  "name": "Sword of Truth",
+  "nameIgnorePrefix": "Sword of Truth",
+  "libraryItemIds": [
+    "li_8gch9ve09orgn4fdz8"
+  ],
+  "numBooks": 1
+}
+```
+
+> Series Books
+
+```json
+{
+  "id": "ser_cabkj4jeu8be3rap4g",
+  "name": "Sword of Truth",
+  "nameIgnorePrefix": "Sword of Truth",
+  "nameIgnorePrefixSort": "Sword of Truth",
+  "type": "series",
+  "books": [...],
+  "addedAt": 1650621073750,
+  "totalDuration": 12000.946
+}
+```
+
+> Series Sequence
+
+```json
+{
+  "id": "ser_cabkj4jeu8be3rap4g",
+  "name": "Sword of Truth",
+  "sequence": "1"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the series.
+`name` | String | The name of the series.
+`description` | String or null | A description for the series. Will be `null` if there is none.
+`addedAt` | Integer | The time (in ms since POSIX epoch) when the series was added.
+`updatedAt` | Integer | The time (in ms since POSIX epoch) when the series was last updated.
+
+### Series Num Books
+
+#### Removed Attributes
+
+* `description`
+* `addedAt`
+* `updatedAt`
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`nameIgnorePrefix` | String | The name of the series with any prefix moved to the end.
+`libraryItemIds` | Array of String | The IDs of the library items in the series.
+`numBooks` | Integer | The number of books in the series.
+
+### Series Books
+
+#### Removed Attributes
+
+* `description`
+* `updatedAt`
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`nameIgnorePrefix` | String | The name of the series with any prefix moved to the end.
+`nameIgnorePrefixSort` | String | The name of the series with any prefix removed.
+`type` | String | Will always be `series`.
+`books` | Array of [Library Item](#library-item) | The library items that contain the books in the series. A `sequence` attribute that denotes the position in the series the book is in, is tacked on.
+`totalDuration` | Float | The combined duration (in seconds) of all books in the series.
+
+### Series Sequence
+
+#### Removed Attributes
+
+* `description`
+* `addedAt`
+* `updatedAt`
+
+#### Added Attributes
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`sequence` | String or null | The position in the series the book is.
+
+
+## Server Settings
+
+> Server Settings
+
+```json
+{
+  "id": "server-settings",
+  "scannerFindCovers": false,
+  "scannerCoverProvider": "google",
+  "scannerParseSubtitle": false,
+  "scannerPreferAudioMetadata": false,
+  "scannerPreferOpfMetadata": false,
+  "scannerPreferMatchedMetadata": false,
+  "scannerDisableWatcher": true,
+  "scannerPreferOverdriveMediaMarker": false,
+  "scannerUseTone": false,
+  "storeCoverWithItem": false,
+  "storeMetadataWithItem": false,
+  "rateLimitLoginRequests": 10,
+  "rateLimitLoginWindow": 600000,
+  "backupSchedule": "30 1 * * *",
+  "backupsToKeep": 2,
+  "maxBackupSize": 1,
+  "backupMetadataCovers": true,
+  "loggerDailyLogsToKeep": 7,
+  "loggerScannerLogsToKeep": 2,
+  "homeBookshelfView": 1,
+  "bookshelfView": 1,
+  "sortingIgnorePrefix": false,
+  "sortingPrefixes": [
+    "the",
+    "a"
+  ],
+  "chromecastEnabled": false,
+  "enableEReader": false,
+  "dateFormat": "MM/dd/yyyy",
+  "timeFormat": "HH:mm",
+  "language": "en-us",
+  "logLevel": 2,
+  "version": "2.2.5"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the server settings.
+`scannerFindCovers` | Boolean | Whether the scanner will attempt to find a cover if your audiobook does not have an embedded cover or a cover image inside the folder. Note: This will extend scan time.
+`scannerCoverProvider` | String | If `scannerFindCovers` is `true`, which metadata provider to use. See [Metadata Providers](#metadata-providers) for options.
+`scannerParseSubtitle` | Boolean | Whether to extract subtitles from audiobook folder names. Subtitles must be separated by ` - `, i.e. `/audiobooks/Book Title - A Subtitle Here/` has the subtitle `A Subtitle Here`.
+`scannerPreferAudioMetadata` | Boolean | Whether to use audio file ID3 meta tags instead of folder names for book details.
+`scannerPreferOpfMetadata` | Boolean | Whether to use OPF file metadata instead of folder names for book details.
+`scannerPreferMatchedMetadata` | Boolean | Whether matched data will override item details when using Quick Match. By default, Quick Match will only fill in missing details.
+`scannerDisableWatcher` | Boolean | Whether to disable the automatic adding/updating of items when file changes are detected. *Requires server restart* for changes to take effect.
+`scannerPreferOverdriveMediaMarker` | Boolean | Whether to use the custom metadata in MP3 files from Overdrive for chapter timings automatically.
+`storeCoverWithItem` | Boolean | Whether to store covers in the library item's folder. By default, covers are stored in `/metadata/items`. Only one file named `cover` will be kept.
+`storeMetadataWithItem` | Boolean | Whether to store metadata files in the library item's folder. By default, metadata files are stored in `/metadata/items`. Uses the `.abs` file extension.
+`rateLimitLoginRequests` | Integer | The maximum number of login requests per `rateLimitLoginWindow`.
+`rateLimitLoginWindow` | Integer | The length (in ms) of each login rate limit window.
+`backupSchedule` | String | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to do automatic backups.
+`backupsToKeep` | Integer | The number of backups to keep.
+`maxBackupSize` | Integer | The maximum backup size (in GB) before they fail, a safeguard against misconfiguration.
+`backupMetadataCovers` | Boolean | Whether backups should include library item covers and author images located in metadata.
+`loggerDailyLogsToKeep` | Integer | The number of daily logs to keep.
+`loggerScannerLogsToKeep` | Integer | The number of scanner logs to keep.
+`homeBookshelfView` | Binary | Whether the home page should use a skeuomorphic design with wooden shelves.
+`bookshelfView` | Binary | Whether other bookshelf pages should use a skeuomorphic design with wooden shelves.
+`sortingIgnorePrefix` | Boolean | Whether to ignore prefixes when sorting. For example, for the prefix `the`, the book title `The Book Title` would sort as `Book Title, The`.
+`sortingPrefixes` | Array of String | If `sortingIgnorePrefix` is `true`, what prefixes to ignore.
+`chromecastEnabled` | Boolean | Whether to enable streaming to Chromecast devices.
+`enableEReader` | Boolean | Whether to enable experimental e-reader support.
+`dateFormat` | String | What date format to use. Options are `MM/dd/yyyy`, `dd/MM/yyyy`, `dd.MM.yyyy`, `yyyy-MM-dd`, `MMM do, yyyy`, `MMMM do, yyyy`, `dd MMM yyyy`, or `dd MMMM yyyy`.
+`timeFormat` | String | What time format to use. Options are `HH:mm` (24-hour) and `h:mma` (am/pm).
+`language` | String | The default server language.
+`logLevel` | Integer | What log level the server should use when logging. `1` for debug, `2` for info, or `3` for warnings.
+`version` | String | The server's version.
+
+
+## Stream
+
+> Stream
+
+```json
+{
+  "id": "play_c786zm3qtjz6bd5q3n",
+  "userId": "root",
+  "libraryItem": {...},
+  "episode": {...},
+  "segmentLength": 6,
+  "playlistPath": "/metadata/streams/play_c786zm3qtjz6bd5q3n/output.m3u8",
+  "clientPlaylistUri": "/hls/play_c786zm3qtjz6bd5q3n/output.m3u8",
+  "startTime": 0,
+  "segmentStartNumber": 0,
+  "isTranscodeComplete": false
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the stream. It will be the same as the ID of the playback session that the stream is for.
+`userId` | String | The ID of the user that started the stream.
+`libraryItem` | [Library Item Expanded](#library-item-expanded) Object | The library item the stream is for.
+`episode` | [Podcast Episode Expanded](#podcast-episode-expanded) Object or null | The podcast episode the stream is for. Will be `null` if the stream is for a book.
+`segmentLength` | Integer | The length (in seconds) of each segment of the stream.
+`playlistPath` | String | The path on the server of the stream output.
+`clientPlaylistUri` | String | The URI path for the client to access the stream.
+`startTime` | Float | The time (in seconds) where the playback session started.
+`segmentStartNumber` | Integer | The segment where the transcoding began.
+`isTranscodeComplete` | Boolean | Whether transcoding is complete.
+
+
+## Stream Progress
+
+> Stream Progress
+
+```json
+{
+  "stream": "play_c786zm3qtjz6bd5q3n",
+  "percent": "8.66%",
+  "chunks": [
+    "0-536"
+  ],
+  "numSegments": 6200
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`stream` | String | The ID of the stream the progress is for.
+`percent` | String | A human-readable percentage of transcode completion.
+`chunks` | Array of String | The segment ranges that have been transcoded.
+`numSegments` | Integer | The total number of segments of the stream.
 
 ## User
 
@@ -1859,491 +2347,3 @@ Attribute | Type | Description
 `accessAllTags` | Boolean | Whether the user can access all tags.
 `accessExplicitContent` | Boolean | Whether the user can access explicit content.
 
-
-## Audio Bookmark
-
-> Audio Bookmark
-
-```json
-{
-  "libraryItemId": "li_8gch9ve09orgn4fdz8",
-  "title": "the good part",
-  "time": 16,
-  "createdAt": 1668120083771
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`libraryItemId` | String | The ID of the library item the bookmark is for.
-`title` | String | The title of the bookmark.
-`time` | Integer | The time (in seconds) the bookmark is at in the book.
-`createdAt` | Integer | The time (in ms since POSIX epoch) when the bookmark was created.
-
-
-## Backup
-
-> Backup
-
-```json
-{
-  "id": "2022-11-14T0130",
-  "backupMetadataCovers": true,
-  "backupDirPath": "/metadata/backups",
-  "datePretty": "Mon, Nov 14 2022 01:30",
-  "fullPath": "/metadata/backups/2022-11-14T0130.audiobookshelf",
-  "path": "backups/2022-11-14T0130.audiobookshelf",
-  "filename": "2022-11-14T0130.audiobookshelf",
-  "fileSize": 7776983,
-  "createdAt": 1668411000329,
-  "serverVersion": "2.2.4"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the backup. Will be the date and time when the backup was created.
-`backupMetadataCovers` | Boolean | Whether the backup includes library item covers and author images located in metadata.
-`backupDirPath` | String | The backup directory path.
-`datePretty` | String | The date and time when the backup was created in a human-readable format.
-`fullPath` | String | The full path of the backup on the server.
-`path` | String | The path of the backup relative to the metadata directory.
-`filename` | String | The filename of the backup.
-`fileSize` | Integer | The size (in bytes) of the backup file.
-`createdAt` | Integer | The time (in ms since POSIX epoch) when the backup was created.
-`serverVersion` | String | The version of the server when the backup was created.
-
-
-## Notification Settings
-
-> Notification Settings
-
-```json
-{
-  "id": "notification-settings",
-  "appriseType": "api",
-  "appriseApiUrl": "https://apprise.example.com/notify",
-  "notifications": [...],
-  "maxFailedAttempts": 5,
-  "maxNotificationQueue": 20,
-  "notificationDelay": 1000
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the notification settings.
-`appriseType` | String | The type of Apprise that will be used. At the moment, only `api` is available.
-`appriseApiUrl` | String or null | The full URL where the Apprise API to use is located.
-`notifications` | Array of [Notification](#notification) | The set notifications.
-`maxFailedAttempts` | Integer | The maximum number of times a notification fails before being disabled.
-`maxNotificationQueue` | Integer | The maximum number of notifications in the notification queue before events are ignored.
-`notificationDelay` | Integer | The time (in ms) between notification pushes.
-
-
-## Notification
-
-> Notification
-
-```json
-{
-  "id": "noti_nod281qwkj5ow7h7fi",
-  "libraryId": null,
-  "eventName": "onPodcastEpisodeDownloaded",
-  "urls": [
-    "apprises://apprise.example.com/email"
-  ],
-  "titleTemplate": "New {{podcastTitle}} Episode!",
-  "bodyTemplate": "{{episodeTitle}} has been added to {{libraryName}} library.",
-  "enabled": true,
-  "type": "info",
-  "lastFiredAt": 1668776410792,
-  "lastAttemptFailed": false,
-  "numConsecutiveFailedAttempts": 0,
-  "numTimesFired": 5,
-  "createdAt": 1666545142424
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the notification.
-`libraryId` | String or null | The ID of the library the notification is associated with.
-`eventName` | String | The name of the event the notification will fire on.
-`urls` | Array of String | The Apprise URLs to use for the notification.
-`titleTemplate` | String | The template for the notification title.
-`bodyTemplate` | String | The template for the notification body.
-`enabled` | Boolean | Whether the notification is enabled.
-`type` | String | The notification's type.
-`lastFiredAt` | Integer or null | The time (in ms since POSIX epoch) when the notification was last fired. Will be `null` if the notification has not fired.
-`lastAttemptFailed` | Boolean | Whether the last notification attempt failed.
-`numConsecutiveFailedAttempts` | Integer | The number of consecutive times the notification has failed.
-`numTimesFired` | Integer | The number of times the notification has fired.
-`createdAt` | Integer | The time (in ms since POSIX epoch) when the notification was created.
-
-
-## Notification Event
-
-> Notification Event
-
-```json
-{
-  "name": "onPodcastEpisodeDownloaded",
-  "requiresLibrary": true,
-  "libraryMediaType": "podcast",
-  "description": "Triggered when a podcast episode is auto-downloaded",
-  "variables": [
-    "libraryItemId",
-    "libraryId",
-    "libraryName",
-    "mediaTags",
-    "podcastTitle",
-    "podcastAuthor",
-    "podcastDescription",
-    "podcastGenres",
-    "episodeId",
-    "episodeTitle",
-    "episodeSubtitle",
-    "episodeDescription"
-  ],
-  "defaults": {
-    "title": "New {{podcastTitle}} Episode!",
-    "body": "{{episodeTitle}} has been added to {{libraryName}} library."
-  },
-  "testData": {
-    "libraryItemId": "li_notification_test",
-    "libraryId": "lib_test",
-    "libraryName": "Podcasts",
-    "podcastTitle": "Abs Test Podcast",
-    "episodeId": "ep_notification_test",
-    "episodeTitle": "Successful Test"
-  }
-}
-```
-
-The notification events that are available are [predefined here](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/notifications.js).
-
-Attribute | Type | Description
---------- | ---- | -----------
-`name` | String | The name of the notification event.
-`requiresLibrary` | Boolean | Whether the notification event depends on a library existing.
-`libraryMediaType` | String | The type of media of the library the notification depends on existing. Will not exist if `requiresLibrary` is `false`.
-`description` | String | The description of the notification event.
-`variables` | Array of String | The variables of the notification event that can be used in the notification templates.
-`defaults.title` | String | The default title template for notifications using the notification event.
-`defaults.body` | String | The default body template for notifications using the notification event.
-`testData` | Object | The keys of the `testData` object will match the list of `variables`. The values will be the data used when sending a test notification.
-
-
-## Server Settings
-
-> Server Settings
-
-```json
-{
-  "id": "server-settings",
-  "scannerFindCovers": false,
-  "scannerCoverProvider": "google",
-  "scannerParseSubtitle": false,
-  "scannerPreferAudioMetadata": false,
-  "scannerPreferOpfMetadata": false,
-  "scannerPreferMatchedMetadata": false,
-  "scannerDisableWatcher": true,
-  "scannerPreferOverdriveMediaMarker": false,
-  "scannerUseTone": false,
-  "storeCoverWithItem": false,
-  "storeMetadataWithItem": false,
-  "rateLimitLoginRequests": 10,
-  "rateLimitLoginWindow": 600000,
-  "backupSchedule": "30 1 * * *",
-  "backupsToKeep": 2,
-  "maxBackupSize": 1,
-  "backupMetadataCovers": true,
-  "loggerDailyLogsToKeep": 7,
-  "loggerScannerLogsToKeep": 2,
-  "homeBookshelfView": 1,
-  "bookshelfView": 1,
-  "sortingIgnorePrefix": false,
-  "sortingPrefixes": [
-    "the",
-    "a"
-  ],
-  "chromecastEnabled": false,
-  "enableEReader": false,
-  "dateFormat": "MM/dd/yyyy",
-  "timeFormat": "HH:mm",
-  "language": "en-us",
-  "logLevel": 2,
-  "version": "2.2.5"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the server settings.
-`scannerFindCovers` | Boolean | Whether the scanner will attempt to find a cover if your audiobook does not have an embedded cover or a cover image inside the folder. Note: This will extend scan time.
-`scannerCoverProvider` | String | If `scannerFindCovers` is `true`, which metadata provider to use. See [Metadata Providers](#metadata-providers) for options.
-`scannerParseSubtitle` | Boolean | Whether to extract subtitles from audiobook folder names. Subtitles must be separated by ` - `, i.e. `/audiobooks/Book Title - A Subtitle Here/` has the subtitle `A Subtitle Here`.
-`scannerPreferAudioMetadata` | Boolean | Whether to use audio file ID3 meta tags instead of folder names for book details.
-`scannerPreferOpfMetadata` | Boolean | Whether to use OPF file metadata instead of folder names for book details.
-`scannerPreferMatchedMetadata` | Boolean | Whether matched data will override item details when using Quick Match. By default, Quick Match will only fill in missing details.
-`scannerDisableWatcher` | Boolean | Whether to disable the automatic adding/updating of items when file changes are detected. *Requires server restart* for changes to take effect.
-`scannerPreferOverdriveMediaMarker` | Boolean | Whether to use the custom metadata in MP3 files from Overdrive for chapter timings automatically.
-`storeCoverWithItem` | Boolean | Whether to store covers in the library item's folder. By default, covers are stored in `/metadata/items`. Only one file named `cover` will be kept.
-`storeMetadataWithItem` | Boolean | Whether to store metadata files in the library item's folder. By default, metadata files are stored in `/metadata/items`. Uses the `.abs` file extension.
-`rateLimitLoginRequests` | Integer | The maximum number of login requests per `rateLimitLoginWindow`.
-`rateLimitLoginWindow` | Integer | The length (in ms) of each login rate limit window.
-`backupSchedule` | String | The [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) for when to do automatic backups.
-`backupsToKeep` | Integer | The number of backups to keep.
-`maxBackupSize` | Integer | The maximum backup size (in GB) before they fail, a safeguard against misconfiguration.
-`backupMetadataCovers` | Boolean | Whether backups should include library item covers and author images located in metadata.
-`loggerDailyLogsToKeep` | Integer | The number of daily logs to keep.
-`loggerScannerLogsToKeep` | Integer | The number of scanner logs to keep.
-`homeBookshelfView` | Binary | Whether the home page should use a skeuomorphic design with wooden shelves.
-`bookshelfView` | Binary | Whether other bookshelf pages should use a skeuomorphic design with wooden shelves.
-`sortingIgnorePrefix` | Boolean | Whether to ignore prefixes when sorting. For example, for the prefix `the`, the book title `The Book Title` would sort as `Book Title, The`.
-`sortingPrefixes` | Array of String | If `sortingIgnorePrefix` is `true`, what prefixes to ignore.
-`chromecastEnabled` | Boolean | Whether to enable streaming to Chromecast devices.
-`enableEReader` | Boolean | Whether to enable experimental e-reader support.
-`dateFormat` | String | What date format to use. Options are `MM/dd/yyyy`, `dd/MM/yyyy`, `dd.MM.yyyy`, `yyyy-MM-dd`, `MMM do, yyyy`, `MMMM do, yyyy`, `dd MMM yyyy`, or `dd MMMM yyyy`.
-`timeFormat` | String | What time format to use. Options are `HH:mm` (24-hour) and `h:mma` (am/pm).
-`language` | String | The default server language.
-`logLevel` | Integer | What log level the server should use when logging. `1` for debug, `2` for info, or `3` for warnings.
-`version` | String | The server's version.
-
-
-## RSS Feed
-
-> RSS Feed
-
-```json
-{
-  "id": "li_bufnnmp4y5o2gbbxfm",
-  "slug": "li_bufnnmp4y5o2gbbxfm",
-  "userId": "root",
-  "entityType": "item",
-  "entityId": "li_bufnnmp4y5o2gbbxfm",
-  "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg",
-  "serverAddress": "https://abs.example.com",
-  "feedUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm",
-  "meta": {...},
-  "episodes": [...],
-  "createdAt": 1669031843179,
-  "updatedAt": 1669031843179
-}
-```
-
-> RSS Feed Minified
-
-```json
-{
-  "id": "li_bufnnmp4y5o2gbbxfm",
-  "entityType": "item",
-  "entityId": "li_bufnnmp4y5o2gbbxfm",
-  "feedUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm",
-  "meta": {
-    "title": "Welcome to Night Vale",
-    "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-    "preventIndexing": true,
-    "ownerName": null,
-    "ownerEmail": null
-  }
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the RSS feed.
-`slug` | String | The slug (the last part of the URL) for the RSS feed.
-`userId` | String | The ID of the user that created the RSS feed.
-`entityType` | String | The type of entity the RSS feed is for.
-`entityId` | String | The ID of the entity the RSS feed is for.
-`coverPath` | String | The path of the cover to use for the RSS feed.
-`serverAddress` | String | The server's address.
-`feedUrl` | String | The full URL of the RSS feed.
-`meta` | [RSS Feed Metadata](#rss-feed-metadata) Object | The RSS feed's metadata.
-`episodes` | Array of [RSS Feed Episode](#rss-feed-episode) | The RSS feed's episodes.
-`createdAt` | Integer | The time (in ms since POSIX epoch) when the RSS feed was created.
-`updatedAt` | Integer | The time (in ms since POSIX epoch) when the RSS feed was last updated.
-
-### RSS Feed Minified
-
-#### Removed Attributes
-
-* `slug`
-* `userId`
-* `coverPath`
-* `serverAddress`
-* `episodes`
-* `createdAt`
-* `updatedAt`
-
-#### Modified Attributes
-
-* `meta` is an [RSS Feed Metadata Minified](#rss-feed-metadata-minified)
-
-
-## RSS Feed Metadata
-
-> RSS Feed Metadata
-
-```json
-{
-  "title": "Welcome to Night Vale",
-  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-  "author": "Night Vale Presents",
-  "imageUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm/cover",
-  "feedUrl": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm",
-  "link": "https://abs.example.com/item/li_bufnnmp4y5o2gbbxfm",
-  "explicit": false,
-  "type": "episodic",
-  "language": "en",
-  "preventIndexing": true,
-  "ownerName": null,
-  "ownerEmail": null
-}
-```
-
-> RSS Feed Metadata Minified
-
-```json
-{
-  "title": "Welcome to Night Vale",
-  "description": "\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\n    ",
-  "preventIndexing": true,
-  "ownerName": null,
-  "ownerEmail": null
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`title` | String | The title of the entity the RSS feed is for.
-`description` | String or null | The description of the entity the RSS feed is for.
-`author` | String or null | The author of the entity the RSS feed is for. 
-`imageUrl` | String | The URL of the RSS feed's image.
-`feedUrl` | String | The URL of the RSS feed.
-`link` | String | The URL of the entity the RSS feed is for.
-`explicit` | Boolean | Whether the RSS feed's contents are explicit.
-`type` | String or null | The type of the RSS feed.
-`language` | String or null | The language of the RSS feed.
-`preventIndexing` | Boolean | Whether the RSS feed is marked to prevent indexing of the feed.
-`ownerName` | String or null | The owner name of the RSS feed.
-`ownerEmail` | String or null | The owner email of the RSS feed.
-
-### RSS Feed Metadata Minified
-
-#### Removed Attributes
-
-* `author`
-* `imageUrl`
-* `feedUrl`
-* `link`
-* `explicit`
-* `type`
-* `language`
-
-
-## RSS Feed Episode
-
-> RSS Feed Episode
-
-```json
-{
-  "id": "ep_lh6ko39pumnrma3dhv",
-  "title": "1 - Pilot",
-  "description": "<div><br>Pilot Episode. A new dog park opens in Night Vale. Carlos, a scientist, visits and discovers some interesting things. Seismic things. Plus, a helpful guide to surveillance helicopter-spotting.<br><br></div><div><br>Weather: \"These and More Than These\" by Joseph Fink<br><br></div><div><br>Music: Disparition, disparition.info<br><br></div><div><br>Logo: Rob Wilson, silastom.com<br><br></div><div><br>Produced by Night Vale Presents. Written by Joseph Fink and Jeffrey Cranor. Narrated by Cecil Baldwin. More Info: welcometonightvale.com, and follow @NightValeRadio on Twitter or Facebook.<br><br></div>",
-  "enclosure": {
-    "url": "https://abs.example.com/feed/li_bufnnmp4y5o2gbbxfm/item/ep_lh6ko39pumnrma3dhv/1 - Pilot.mp3",
-    "type": "audio/mpeg",
-    "size": 23653735
-  },
-  "pubDate": "Fri, 15 Jun 2012 12:00:00 -0000",
-  "link": "https://abs.example.com/item/li_bufnnmp4y5o2gbbxfm",
-  "author": "Night Vale Presents",
-  "explicit": false,
-  "duration": 1454.18449,
-  "season": null,
-  "episode": null,
-  "episodeType": null,
-  "libraryItemId": "li_bufnnmp4y5o2gbbxfm",
-  "episodeId": "ep_lh6ko39pumnrma3dhv",
-  "trackIndex": 0,
-  "fullPath": "/podcasts/Welcome to Night Vale/1 - Pilot.mp3"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the RSS feed episode.
-`title` | String | The title of the RSS feed episode.
-`description` | String | An HTML encoded description of the RSS feed episode.
-`enclosure` | Similar to [Podcast Episode Enclosure](#podcast-episode-enclosure) | Download information for the RSS feed episode.
-`pubDate` | String | The RSS feed episode's publication date.
-`link` | String | A URL to display to the RSS feed user.
-`author` | String | The author of the RSS feed episode.
-`explicit` | Boolean | Whether the RSS feed episode is explicit.
-`duration` | Float | The duration (in seconds) of the RSS feed episode.
-`season` | String or null | The season of the RSS feed episode.
-`episode` | String or null | The episode number of the RSS feed episode.
-`episodeType` | String or null | The type of the RSS feed episode.
-`libraryItemId` | String | The ID of the library item the RSS feed is for.
-`episodeId` | String or null | The ID of the podcast episode the RSS feed episode is for. Will be `null` if the RSS feed is for a book.
-`trackIndex` | Integer | The RSS feed episode's track index.
-`fullPath` | String | The path on the server of the audio file the RSS feed episode is for.
-
-
-## Stream
-
-> Stream
-
-```json
-{
-  "id": "play_c786zm3qtjz6bd5q3n",
-  "userId": "root",
-  "libraryItem": {...},
-  "episode": {...},
-  "segmentLength": 6,
-  "playlistPath": "/metadata/streams/play_c786zm3qtjz6bd5q3n/output.m3u8",
-  "clientPlaylistUri": "/hls/play_c786zm3qtjz6bd5q3n/output.m3u8",
-  "startTime": 0,
-  "segmentStartNumber": 0,
-  "isTranscodeComplete": false
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the stream. It will be the same as the ID of the playback session that the stream is for.
-`userId` | String | The ID of the user that started the stream.
-`libraryItem` | [Library Item Expanded](#library-item-expanded) Object | The library item the stream is for.
-`episode` | [Podcast Episode Expanded](#podcast-episode-expanded) Object or null | The podcast episode the stream is for. Will be `null` if the stream is for a book.
-`segmentLength` | Integer | The length (in seconds) of each segment of the stream.
-`playlistPath` | String | The path on the server of the stream output.
-`clientPlaylistUri` | String | The URI path for the client to access the stream.
-`startTime` | Float | The time (in seconds) where the playback session started.
-`segmentStartNumber` | Integer | The segment where the transcoding began.
-`isTranscodeComplete` | Boolean | Whether transcoding is complete.
-
-
-## Stream Progress
-
-> Stream Progress
-
-```json
-{
-  "stream": "play_c786zm3qtjz6bd5q3n",
-  "percent": "8.66%",
-  "chunks": [
-    "0-536"
-  ],
-  "numSegments": 6200
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`stream` | String | The ID of the stream the progress is for.
-`percent` | String | A human-readable percentage of transcode completion.
-`chunks` | Array of String | The segment ranges that have been transcoded.
-`numSegments` | Integer | The total number of segments of the stream.

--- a/source/includes/_search.md
+++ b/source/includes/_search.md
@@ -1,65 +1,5 @@
 # Search
 
-## Search for Covers
-
-```shell
-curl "https://abs.example.com/api/search/covers?title=Wizards%20First%20Rule&author=Terry%20Goodkind&provider=openlibrary" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "results": [
-    "https://covers.openlibrary.org/b/id/1005963-L.jpg",
-    "https://covers.openlibrary.org/b/id/791977-L.jpg",
-    "https://covers.openlibrary.org/b/id/766531-L.jpg",
-    "https://covers.openlibrary.org/b/id/910943-L.jpg",
-    "https://covers.openlibrary.org/b/id/8782857-L.jpg",
-    "https://covers.openlibrary.org/b/id/8788596-L.jpg",
-    "https://covers.openlibrary.org/b/id/8783892-L.jpg",
-    "https://covers.openlibrary.org/b/id/8993240-L.jpg",
-    "https://covers.openlibrary.org/b/id/10505009-L.jpg",
-    "https://covers.openlibrary.org/b/id/1005881-L.jpg",
-    "https://covers.openlibrary.org/b/id/8776837-L.jpg",
-    "https://covers.openlibrary.org/b/id/10778344-L.jpg",
-    "https://covers.openlibrary.org/b/id/11239659-L.jpg",
-    "https://covers.openlibrary.org/b/id/12224404-L.jpg",
-    "https://covers.openlibrary.org/b/OLID/OL9034948M-L.jpg",
-    "https://covers.openlibrary.org/b/id/8785389-L.jpg"
-  ]
-}
-```
-
-This endpoint searches a metadata provider for covers.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/search/covers`
-
-### Query Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-`podcast` | Binary | `0` | Whether to search for podcast covers. Only the `title` parameter is needed for podcasts. `0` for false, `1` for true.
-`title` | String | **Required** | The media title to search for.
-`author` | String or null | `null` | If searching for a book cover, the author to search for.
-`provider` | String | `google` | If searching for a book cover, the metadata provider to use. See [Metadata Providers](#metadata-providers) for options.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`results` | Array of String | URLs of cover image search results.
-
-
 ## Search for Books
 
 > Metadata Provider: Google
@@ -332,6 +272,66 @@ Attribute | Type | Description
 `isbn` | String or null | The book's ISBN.
 
 
+## Search for Covers
+
+```shell
+curl "https://abs.example.com/api/search/covers?title=Wizards%20First%20Rule&author=Terry%20Goodkind&provider=openlibrary" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "results": [
+    "https://covers.openlibrary.org/b/id/1005963-L.jpg",
+    "https://covers.openlibrary.org/b/id/791977-L.jpg",
+    "https://covers.openlibrary.org/b/id/766531-L.jpg",
+    "https://covers.openlibrary.org/b/id/910943-L.jpg",
+    "https://covers.openlibrary.org/b/id/8782857-L.jpg",
+    "https://covers.openlibrary.org/b/id/8788596-L.jpg",
+    "https://covers.openlibrary.org/b/id/8783892-L.jpg",
+    "https://covers.openlibrary.org/b/id/8993240-L.jpg",
+    "https://covers.openlibrary.org/b/id/10505009-L.jpg",
+    "https://covers.openlibrary.org/b/id/1005881-L.jpg",
+    "https://covers.openlibrary.org/b/id/8776837-L.jpg",
+    "https://covers.openlibrary.org/b/id/10778344-L.jpg",
+    "https://covers.openlibrary.org/b/id/11239659-L.jpg",
+    "https://covers.openlibrary.org/b/id/12224404-L.jpg",
+    "https://covers.openlibrary.org/b/OLID/OL9034948M-L.jpg",
+    "https://covers.openlibrary.org/b/id/8785389-L.jpg"
+  ]
+}
+```
+
+This endpoint searches a metadata provider for covers.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/search/covers`
+
+### Query Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`podcast` | Binary | `0` | Whether to search for podcast covers. Only the `title` parameter is needed for podcasts. `0` for false, `1` for true.
+`title` | String | **Required** | The media title to search for.
+`author` | String or null | `null` | If searching for a book cover, the author to search for.
+`provider` | String | `google` | If searching for a book cover, the metadata provider to use. See [Metadata Providers](#metadata-providers) for options.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`results` | Array of String | URLs of cover image search results.
+
+
 ## Search for Podcasts
 
 ```shell
@@ -403,54 +403,6 @@ Attribute | Type | Description
 `feedUrl` | String | The URL of the podcast's RSS feed.
 `pageUrl` | String | The URL of the podcast's iTunes page.
 `explicit` | Boolean | Whether the podcast is marked as explicit.
-
-
-## Search for an Author
-
-```shell
-curl "https://abs.example.com/api/search/authors?q=Terry%20Goodkind" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "asin": "B000APZOQA",
-  "description": "Terry Goodkind is a #1 New York Times Bestselling Author and creator of the critically acclaimed masterwork, ‘The Sword of Truth’. He has written 30+ major, bestselling novels, has been published in more than 20 languages world-wide, and has sold more than 26 Million books. ‘The Sword of Truth’ is a revered literary tour de force, comprised of 17 volumes, borne from over 25 years of dedicated writing. Terry Goodkind's brilliant books are character-driven stories, with a focus on the complexity of the human psyche. Goodkind has an uncanny grasp for crafting compelling stories about people like you and me, trapped in terrifying situations. With masterful storytelling, Goodkind brings us into the lives of his characters; characters that must rise to face not only challenges, but their deepest fears. For that reason, Goodkind’s characters speak to the best and worst in all of us. While ‘The Sword of Truth’ series is confirmation enough of Goodkind’s incredible storytelling abilities, his broad talents are also clearly evident in his contemporary novels, set within our own world. His post-‘Sword of Truth’ books are a thrilling, dizzying, mix of modern narrative, with every bit of Goodkind’s masterful voice intact. The bond built between the reader and one of the world’s great authors, rises above worlds and settings, mere backdrops for Goodkind’s uniquely intricate stories of life, love, challenge, and triumph. \"My privilege in life is the joy of writing books and telling stories about people who fascinate me, the good and the bad. I am grateful to all of my readers for the critical role they play in making these books possible. Your passion is my passion, and I thank you.\" - Terry Goodkind For more, please visit: http://terrygoodkind.com",
-  "image": "https://images-na.ssl-images-amazon.com/images/I/51NoQTm33OL.jpg",
-  "name": "Terry Goodkind"
-}
-```
-
-This endpoint searches [Audnexus](https://github.com/laxamentumtech/audnexus) (which mostly uses Audible for its data) for authors.
-
-### HTTP Request
-
-`GET http://abs.example.com/api/search/authors`
-
-### Query Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`q` | String | The search query. The provided name must match the author's name on Audnexus exactly to get a result.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-
-#### Response Schema
-
-Either `null` or an object with the following attributes will be returned.
-
-Attribute | Type | Description
---------- | ---- | -----------
-`asin` | String | The author's ASIN.
-`description` | String | The author's description.
-`image` | String | The URL of the author's image.
-`name` | String | The author's name.
 
 
 ## Search for a Book's Chapters
@@ -720,3 +672,50 @@ Attribute | Type | Description
 `startOffsetMs` | Integer | The start offset (in ms) of the chapter.
 `startOffsetSec` | Integer | The start offset (in seconds) of the chapter.
 `title` | String | The chapter's title.
+
+## Search for an Author
+
+```shell
+curl "https://abs.example.com/api/search/authors?q=Terry%20Goodkind" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "asin": "B000APZOQA",
+  "description": "Terry Goodkind is a #1 New York Times Bestselling Author and creator of the critically acclaimed masterwork, ‘The Sword of Truth’. He has written 30+ major, bestselling novels, has been published in more than 20 languages world-wide, and has sold more than 26 Million books. ‘The Sword of Truth’ is a revered literary tour de force, comprised of 17 volumes, borne from over 25 years of dedicated writing. Terry Goodkind's brilliant books are character-driven stories, with a focus on the complexity of the human psyche. Goodkind has an uncanny grasp for crafting compelling stories about people like you and me, trapped in terrifying situations. With masterful storytelling, Goodkind brings us into the lives of his characters; characters that must rise to face not only challenges, but their deepest fears. For that reason, Goodkind’s characters speak to the best and worst in all of us. While ‘The Sword of Truth’ series is confirmation enough of Goodkind’s incredible storytelling abilities, his broad talents are also clearly evident in his contemporary novels, set within our own world. His post-‘Sword of Truth’ books are a thrilling, dizzying, mix of modern narrative, with every bit of Goodkind’s masterful voice intact. The bond built between the reader and one of the world’s great authors, rises above worlds and settings, mere backdrops for Goodkind’s uniquely intricate stories of life, love, challenge, and triumph. \"My privilege in life is the joy of writing books and telling stories about people who fascinate me, the good and the bad. I am grateful to all of my readers for the critical role they play in making these books possible. Your passion is my passion, and I thank you.\" - Terry Goodkind For more, please visit: http://terrygoodkind.com",
+  "image": "https://images-na.ssl-images-amazon.com/images/I/51NoQTm33OL.jpg",
+  "name": "Terry Goodkind"
+}
+```
+
+This endpoint searches [Audnexus](https://github.com/laxamentumtech/audnexus) (which mostly uses Audible for its data) for authors.
+
+### HTTP Request
+
+`GET http://abs.example.com/api/search/authors`
+
+### Query Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`q` | String | The search query. The provided name must match the author's name on Audnexus exactly to get a result.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+
+#### Response Schema
+
+Either `null` or an object with the following attributes will be returned.
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`asin` | String | The author's ASIN.
+`description` | String | The author's description.
+`image` | String | The URL of the author's image.
+`name` | String | The author's name.

--- a/source/includes/_series.md
+++ b/source/includes/_series.md
@@ -1,54 +1,5 @@
 # Series Endpoints
 
-## Search for Series
-
-```shell
-curl "https://abs.example.com/api/series/search?q=Sword" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "results": [
-    {
-      "id": "ser_cabkj4jeu8be3rap4g",
-      "name": "Sword of Truth",
-      "description": null,
-      "addedAt": 1650621073750,
-      "updatedAt": 1650621073750
-    }
-  ]
-}
-```
-
-This endpoint searches for series that match the query and returns the results.
-
-### HTTP Request
-
-`GET https://abs.example.com/api/series/search?<q>`
-
-### Query Parameters
-
-Parameter | Type | Default | Description
---------- | ---- | ------- | -----------
-q | String | **Required** | The URL encoded search query.
-limit | Integer | `25` | Limit the number of returned results.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`results` | Array of [Series](#series) | The series search results.
-
-
 ## Get a Series
 
 ```shell
@@ -116,6 +67,55 @@ Attribute | Type | Description
 `libraryItemIds`| Array of String | The IDs of the library items in the series.
 `libraryItemIdsFinished` | Array of String | The IDs of the library items in the series that are finished.
 `isFinished` | Boolean | Whether the series is finished.
+
+
+## Search for Series
+
+```shell
+curl "https://abs.example.com/api/series/search?q=Sword" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "results": [
+    {
+      "id": "ser_cabkj4jeu8be3rap4g",
+      "name": "Sword of Truth",
+      "description": null,
+      "addedAt": 1650621073750,
+      "updatedAt": 1650621073750
+    }
+  ]
+}
+```
+
+This endpoint searches for series that match the query and returns the results.
+
+### HTTP Request
+
+`GET https://abs.example.com/api/series/search?<q>`
+
+### Query Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+q | String | **Required** | The URL encoded search query.
+limit | Integer | `25` | Limit the number of returned results.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`results` | Array of [Series](#series) | The series search results.
 
 
 ## Update a Series

--- a/source/includes/_server.md
+++ b/source/includes/_server.md
@@ -1,5 +1,95 @@
 # Server
 
+## Check the Server's Status
+
+```shell
+curl "https://abs.example.com/status"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "isInit": true,
+  "language": "en-us"
+}
+```
+
+This endpoint reports the server's initialization status.
+
+### HTTP Request
+
+`GET http://abs.example.com/status`
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`isInit` | Boolean | Whether the server has been initialized.
+`language` | String | The server's default language.
+`ConfigPath` | String | The server's config path. Will only exist if `isInit` is `false`.
+`MetadataPath` | String | The server's metadata path. Will only exist if `isInit` is `false`.
+
+
+## Healthcheck
+
+```shell
+curl "https://abs.example.com/healthcheck"
+```
+
+This endpoint is a simple check to see if the server is operating and can respond.
+
+### HTTP Request
+
+`GET http://abs.example.com/healthcheck`
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+
+## Initialize the Server
+
+```shell
+curl -X POST "https://abs.example.com/init" \
+  -H "Content-Type: application/json" \
+  -d '{"newRoot": {"username": "root", "password": "*****"}}'
+```
+
+This endpoint initializes a server for use with a root user. This is required for new servers without a root user yet.
+
+### HTTP Request
+
+`POST http://abs.example.com/init`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`newRoot` | [New Root User](#new-root-user-parameters) Object (See Below) | The new root user.
+
+#### New Root User Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`username` | String | The username of the new root user.
+`password` | String | The password of the new root user, may be empty.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+500 | Internal Server Error | The server has already been initialized.
+
+
 ## Login
 
 ```shell
@@ -150,78 +240,6 @@ Status | Meaning | Description
 200 | OK | Success
 
 
-## Initialize the Server
-
-```shell
-curl -X POST "https://abs.example.com/init" \
-  -H "Content-Type: application/json" \
-  -d '{"newRoot": {"username": "root", "password": "*****"}}'
-```
-
-This endpoint initializes a server for use with a root user. This is required for new servers without a root user yet.
-
-### HTTP Request
-
-`POST http://abs.example.com/init`
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`newRoot` | [New Root User](#new-root-user-parameters) Object (See Below) | The new root user.
-
-#### New Root User Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`username` | String | The username of the new root user.
-`password` | String | The password of the new root user, may be empty.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-500 | Internal Server Error | The server has already been initialized.
-
-
-## Check the Server's Status
-
-```shell
-curl "https://abs.example.com/status"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "isInit": true,
-  "language": "en-us"
-}
-```
-
-This endpoint reports the server's initialization status.
-
-### HTTP Request
-
-`GET http://abs.example.com/status`
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`isInit` | Boolean | Whether the server has been initialized.
-`language` | String | The server's default language.
-`ConfigPath` | String | The server's config path. Will only exist if `isInit` is `false`.
-`MetadataPath` | String | The server's metadata path. Will only exist if `isInit` is `false`.
-
-
 ## Ping the Server
 
 ```shell
@@ -253,22 +271,3 @@ Status | Meaning | Description | Schema
 Attribute | Type | Description
 --------- | ---- | -----------
 `success` | Boolean | Will always be `true`.
-
-
-## Healthcheck
-
-```shell
-curl "https://abs.example.com/healthcheck"
-```
-
-This endpoint is a simple check to see if the server is operating and can respond.
-
-### HTTP Request
-
-`GET http://abs.example.com/healthcheck`
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success

--- a/source/includes/_sessions.md
+++ b/source/includes/_sessions.md
@@ -1,5 +1,69 @@
 # Sessions
 
+## Close an Open Session
+
+```shell
+curl -X POST "https://abs.example.com/api/session/play_i00492kps6ow4axlvq/close" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"currentTime": 636.09262, "timeListened": 5, "duration": 1454.18449}'
+```
+
+This endpoint closes an open listening session. Optionally provide sync data to update the session before closing it.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/session/<ID>/close`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the listening session.
+
+### Optional Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`currentTime` | Float | The current time (in seconds) of the playback position.
+`timeListened` | Float | The amount of time (in seconds) the user has spent listening since the last session sync.
+`duration` | Float | The total duration (in seconds) of the playing item.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+404 | Not Found | No listening session with the provided ID is open, or the session belongs to another user.
+
+## Delete a Session
+
+```shell
+curl -X DELETE "https://abs.example.com/api/sessions/play_4oq00chunexu9s03jw" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint deletes a listening session.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/sessions/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the listening session.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | A user with delete permissions is required to delete sessions.
+404 | Not Found | No session with provided ID exists.
+
+
 ## Get All Sessions
 
 ```shell
@@ -112,118 +176,6 @@ Attribute | Type | Description
 --------- | ---- | -----------
 `id` | String | The ID of the user.
 `username` | String | The username of the user.
-
-
-## Delete a Session
-
-```shell
-curl -X DELETE "https://abs.example.com/api/sessions/play_4oq00chunexu9s03jw" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint deletes a listening session.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/sessions/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the listening session.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | A user with delete permissions is required to delete sessions.
-404 | Not Found | No session with provided ID exists.
-
-
-## Sync a Local Session
-
-```shell
-curl -X POST "https://abs.example.com/api/session/local" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d $'{"id": "play_local_i00492kps6ow4axlvq", "userId": "root", "libraryId": "lib_p9wkw2i85qy9oltijt", "libraryItemId": "li_bufnnmp4y5o2gbbxfm", "episodeId": "ep_lh6ko39pumnrma3dhv", "mediaType": "podcast", "mediaMetadata": {"title": "Welcome to Night Vale", "author": "Night Vale Presents", "description": "\\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It\'s an ongoing radio show. Start with the current episode, and you\'ll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\\n    ", "releaseDate": "2022-10-20T19:00:00Z", "genres": ["Science Fiction", "Podcasts", "Fiction"], "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast", "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg", "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4", "itunesId": 536258179, "itunesArtistId": 718704794, "explicit": false, "language": null}, "chapters": [], "displayTitle": "1 - Pilot", "displayAuthor": "Night Vale Presents", "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg", "duration": 1454.18449, "playMethod": 0, "mediaPlayer": "html5", "deviceInfo": {"ipAddress": "192.168.1.118", "browserName": "Firefox", "browserVersion": "106.0", "osName": "Linux", "osVersion": "x86_64", "serverVersion": "2.2.4"}, "date": "2022-11-16", "dayOfWeek": "Wednesday", "timeListening": 20, "startTime": 616.291374, "currentTime": 636.09262, "startedAt": 1668580247687, "updatedAt": 1668580396623}'
-```
-
-This endpoint updates a local listening session on the server.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/session/local`
-
-### Parameters
-
-Provide the local [Playback Session](#playback-session) as the body.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-500 | Internal Server Error | Either the local session is already syncing, or the library item was not found.
-
-
-## Sync Local Sessions
-
-```shell
-curl -X POST "https://abs.example.com/api/session/local-all" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d $'{"sessions": [{"id": "play_local_i00492kps6ow4axlvq", "userId": "root", "libraryId": "lib_p9wkw2i85qy9oltijt", "libraryItemId": "li_bufnnmp4y5o2gbbxfm", "episodeId": "ep_lh6ko39pumnrma3dhv", "mediaType": "podcast", "mediaMetadata": {"title": "Welcome to Night Vale", "author": "Night Vale Presents", "description": "\\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It\'s an ongoing radio show. Start with the current episode, and you\'ll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\\n    ", "releaseDate": "2022-10-20T19:00:00Z", "genres": ["Science Fiction", "Podcasts", "Fiction"], "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast", "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg", "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4", "itunesId": 536258179, "itunesArtistId": 718704794, "explicit": false, "language": null}, "chapters": [], "displayTitle": "1 - Pilot", "displayAuthor": "Night Vale Presents", "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg", "duration": 1454.18449, "playMethod": 0, "mediaPlayer": "html5", "deviceInfo": {"ipAddress": "192.168.1.118", "browserName": "Firefox", "browserVersion": "106.0", "osName": "Linux", "osVersion": "x86_64", "serverVersion": "2.2.4"}, "date": "2022-11-16", "dayOfWeek": "Wednesday", "timeListening": 20, "startTime": 616.291374, "currentTime": 636.09262, "startedAt": 1668580247687, "updatedAt": 1668580396623}]}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "results": [
-    {
-      "id": "play_local_i00492kps6ow4axlvq",
-      "success": true,
-      "progressSynced": true
-    }
-  ]
-}
-```
-
-This endpoint updates local listening sessions on the server.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/session/local-all`
-
-### Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`sessions` | Array of [Playback Session](#playback-session) | The local playback sessions to sync.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See Below
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`results` | Array of [Sync Local Session Result](#sync-local-session-result) | The results from the session syncs.
-
-#### Sync Local Session Result
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the playback session.
-`success` | Boolean | Whether the session was successfully synced.
-`error` | String | Will only exist if `success` is `false`. The error that occurred when syncing.
-`progressSynced` | Boolean | Will only exist if `success` is `true`. Whether the progress for the session's library item was updated.
 
 
 ## Get an Open Session
@@ -496,6 +448,90 @@ Status | Meaning | Description | Schema
 404 | Not Found | No listening session with the provided ID is open, or the session belongs to another user. |
 
 
+## Sync Local Sessions
+
+```shell
+curl -X POST "https://abs.example.com/api/session/local-all" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d $'{"sessions": [{"id": "play_local_i00492kps6ow4axlvq", "userId": "root", "libraryId": "lib_p9wkw2i85qy9oltijt", "libraryItemId": "li_bufnnmp4y5o2gbbxfm", "episodeId": "ep_lh6ko39pumnrma3dhv", "mediaType": "podcast", "mediaMetadata": {"title": "Welcome to Night Vale", "author": "Night Vale Presents", "description": "\\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It\'s an ongoing radio show. Start with the current episode, and you\'ll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\\n    ", "releaseDate": "2022-10-20T19:00:00Z", "genres": ["Science Fiction", "Podcasts", "Fiction"], "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast", "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg", "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4", "itunesId": 536258179, "itunesArtistId": 718704794, "explicit": false, "language": null}, "chapters": [], "displayTitle": "1 - Pilot", "displayAuthor": "Night Vale Presents", "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg", "duration": 1454.18449, "playMethod": 0, "mediaPlayer": "html5", "deviceInfo": {"ipAddress": "192.168.1.118", "browserName": "Firefox", "browserVersion": "106.0", "osName": "Linux", "osVersion": "x86_64", "serverVersion": "2.2.4"}, "date": "2022-11-16", "dayOfWeek": "Wednesday", "timeListening": 20, "startTime": 616.291374, "currentTime": 636.09262, "startedAt": 1668580247687, "updatedAt": 1668580396623}]}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "results": [
+    {
+      "id": "play_local_i00492kps6ow4axlvq",
+      "success": true,
+      "progressSynced": true
+    }
+  ]
+}
+```
+
+This endpoint updates local listening sessions on the server.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/session/local-all`
+
+### Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`sessions` | Array of [Playback Session](#playback-session) | The local playback sessions to sync.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See Below
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`results` | Array of [Sync Local Session Result](#sync-local-session-result) | The results from the session syncs.
+
+#### Sync Local Session Result
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the playback session.
+`success` | Boolean | Whether the session was successfully synced.
+`error` | String | Will only exist if `success` is `false`. The error that occurred when syncing.
+`progressSynced` | Boolean | Will only exist if `success` is `true`. Whether the progress for the session's library item was updated.
+
+
+## Sync a Local Session
+
+```shell
+curl -X POST "https://abs.example.com/api/session/local" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d $'{"id": "play_local_i00492kps6ow4axlvq", "userId": "root", "libraryId": "lib_p9wkw2i85qy9oltijt", "libraryItemId": "li_bufnnmp4y5o2gbbxfm", "episodeId": "ep_lh6ko39pumnrma3dhv", "mediaType": "podcast", "mediaMetadata": {"title": "Welcome to Night Vale", "author": "Night Vale Presents", "description": "\\n      Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It\'s an ongoing radio show. Start with the current episode, and you\'ll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.\\n    ", "releaseDate": "2022-10-20T19:00:00Z", "genres": ["Science Fiction", "Podcasts", "Fiction"], "feedUrl": "http://feeds.nightvalepresents.com/welcometonightvalepodcast", "imageUrl": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts125/v4/4a/31/35/4a3135d0-1fe7-a2d7-fb43-d182ec175402/mza_8232698753950666850.jpg/600x600bb.jpg", "itunesPageUrl": "https://podcasts.apple.com/us/podcast/welcome-to-night-vale/id536258179?uo=4", "itunesId": 536258179, "itunesArtistId": 718704794, "explicit": false, "language": null}, "chapters": [], "displayTitle": "1 - Pilot", "displayAuthor": "Night Vale Presents", "coverPath": "/metadata/items/li_bufnnmp4y5o2gbbxfm/cover.jpg", "duration": 1454.18449, "playMethod": 0, "mediaPlayer": "html5", "deviceInfo": {"ipAddress": "192.168.1.118", "browserName": "Firefox", "browserVersion": "106.0", "osName": "Linux", "osVersion": "x86_64", "serverVersion": "2.2.4"}, "date": "2022-11-16", "dayOfWeek": "Wednesday", "timeListening": 20, "startTime": 616.291374, "currentTime": 636.09262, "startedAt": 1668580247687, "updatedAt": 1668580396623}'
+```
+
+This endpoint updates a local listening session on the server.
+
+### HTTP Request
+
+`POST http://abs.example.com/api/session/local`
+
+### Parameters
+
+Provide the local [Playback Session](#playback-session) as the body.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+500 | Internal Server Error | Either the local session is already syncing, or the library item was not found.
+
+
 ## Sync an Open Session
 
 ```shell
@@ -533,39 +569,3 @@ Status | Meaning | Description
 404 | Not Found | No listening session with the provided ID is open, or the session belongs to another user.
 500 | Internal Server Error | There was an error syncing the session.
 
-
-## Close an Open Session
-
-```shell
-curl -X POST "https://abs.example.com/api/session/play_i00492kps6ow4axlvq/close" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"currentTime": 636.09262, "timeListened": 5, "duration": 1454.18449}'
-```
-
-This endpoint closes an open listening session. Optionally provide sync data to update the session before closing it.
-
-### HTTP Request
-
-`POST http://abs.example.com/api/session/<ID>/close`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the listening session.
-
-### Optional Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`currentTime` | Float | The current time (in seconds) of the playback position.
-`timeListened` | Float | The amount of time (in seconds) the user has spent listening since the last session sync.
-`duration` | Float | The total duration (in seconds) of the playing item.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-404 | Not Found | No listening session with the provided ID is open, or the session belongs to another user.

--- a/source/includes/_socket.md
+++ b/source/includes/_socket.md
@@ -1,284 +1,5 @@
 # Socket
 
-Audiobookshelf uses [Socket.io](https://socket.io/) for bidirectional communication between clients and the server.
-Each client must first authenticate itself using a user's API token in order to subscribe to events for that user.
-There is also [an example](https://github.com/advplyr/abs-socket-client-demo) for how to use the socket.
-
-<aside class="notice">
-If the socket gets disconnected and then re-connects, it will have a new socket ID and will need to authenticate again.
-</aside>
-
-## Client Events
-
-> `auth`
-
-```js
-socket.emit('auth', 'exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY')
-```
-
-> `cancel_scan`
-
-```js
-socket.emit('cancel_scan', 'lib_c1u6t4p45c35rf0nzd')
-```
-
-> `set_log_listener`
-
-```js
-socket.emit('set_log_listener', 2)
-```
-
-> `message_all_users`
-
-```js
-socket.emit('message_all_users', { message: 'Message from admin' })
-```
-
-These are events that clients can emit. See [Miscellaneous Events](#miscellaneous-events) for events that the server responds to these events with.
-
-Name | Description | Schema
----- | ----------- | ------
-`auth` | Authenticates the socket connection. Causes the server to emit the `init` or `invalid_token` event. | API Token String
-`cancel_scan` | Cancels an in progress library scan. | Library ID String
-`set_log_listener` | Makes the server emit `log` events of the given level or below to the client. | Log Level Integer: `1` for debug, `2` for info, or `3` for warnings, `4` for errors.
-`remove_log_listener` | Removes the client as a log listener. |
-`fetch_daily_logs` | Causes the server to emit the `daily_logs` event. |
-`message_all_users` | **Admin Users Only** Send a message to all users using the `admin_message` server event. | [Message All Users](#message-all-users) Object
-`ping` | Causes the server to emit the `pong` event. |
-
-### Message All Users
-
-Attribute | Type | Description
---------- | ---- | -----------
-`message` | String | The message to send to all users.
-
-
-## Server Events
-
-The events that the server can emit are in the sections below.
-Events marked with "**Admin Only**" are only sent to sockets with an authenticated admin user.
-
-
-## User Events
-
-Name | Description | Schema
----- | ----------- | ------
-`user_online` | **Admin Only** A user is online. | [User with Session and Most Recent Progress](#user-with-session-and-most-recent-progress) Object
-`user_offline` | **Admin Only** A user is offline. | [User with Session and Most Recent Progress](#user-with-session-and-most-recent-progress) Object
-`user_added` | **Admin Only** A user was created. | [User](#user) Object
-`user_updated` | The authenticated user has been updated. | [User](#user) Object
-`user_removed` | **Admin Only** A user was deleted. | [User](#user) Object
-`user_item_progress_updated` | One of the authenticated user's media progress was created/updated. | [User Item Progress Updated Event](#user-item-progress-updated-event)
-`user_stream_update` | **Admin Only** A user started or stopped a playback session. | [User with Session and Most Recent Progress](#user-with-session-and-most-recent-progress) Object
-
-### User Item Progress Updated Event
-
-> User Item Progress Updated Event
-
-```json
-{
-  "id": "li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv",
-  "data": {...}
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the updated media progress.
-`data` | [Media Progress](#media-progress) Object | The updated media progress.
-
-
-## Stream Events
-
-Name | Description | Schema
----- | ----------- | ------
-`stream_open` | A stream has opened. | [Stream](#stream) Object
-`stream_closed` | A stream has closed. | Stream ID String
-`stream_progress` | A stream transcode progress update. | [Stream Progress](#stream-progress) Object
-`stream_ready` | A stream is ready, transcoding has already been completed on the requested stream. |
-`stream_reset` | A stream was reset. | [Stream Reset Event](#stream-reset-event) Object
-`stream_error` | A stream error occurred. Emitted when ffmpeg has an error while transcoding. | [Stream Error Event](#stream-error-event) Object
-
-### Stream Reset Event
-
-> Stream Reset Event
-
-```json
-{
-  "startTime": 0,
-  "streamId": "play_c786zm3qtjz6bd5q3n"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`startTime` | Float | The new start time (in seconds) of the stream.
-`streamId` | String | The ID of the stream being reset.
-
-### Stream Error Event
-
-> Stream Error Event
-
-```json
-{
-  "id": "play_c786zm3qtjz6bd5q3n",
-  "error": "ffmpeg exited with code 1"
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the stream where the error occurred.
-`error` | String | The error's message.
-
-
-## Library Events
-
-Name | Description | Schema
----- | ----------- | ------
-`library_added` | A library was created. | [Library](#library) Object
-`library_updated` | A library was updated. | [Library](#library) Object
-`library_removed` | A library was deleted. | [Library](#library) Object
-
-
-## Library Scan Events
-
-Name | Description | Schema
----- | ----------- | ------
-`scan_start` | A library scan was started. | [Library Scan](#library-scan) Object
-`scan_complete` | A library scan was completed. | [Library Scan](#library-scan) Object
-
-### Library Scan
-
-> Library Scan
-
-```json
-{
-  "id": "lib_yq748byukae93rulli",
-  "type": "scan",
-  "name": "Audiobooks",
-  "results": {...}
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`id` | String | The ID of the scanned library.
-`type` | String | The type of the library scan. Will be `scan` or `match`.
-`name` | String | The name of the scanned library.
-`results` | [Library Scan Results](#library-scan-results) Object or null | The results of the library scan. Will be `null` if the scan was canceled.
-
-### Library Scan Results
-
-> Library Scan Results
-
-```json
-{
-  "added": 0,
-  "updated": 0,
-  "missing": 0
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`added` | Integer | The number of library items added during the scan.
-`updated` | Integer | The number of library items updated during the scan.
-`missing` | Integer | The number of library items discovered to be missing during the scan.
-
-
-## Library Item Events
-
-Name | Description | Schema
----- | ----------- | ------
-`item_added` | A library item was created. | [Library Item Expanded](#library-item-expanded) Object
-`item_updated` | A library item was updated. | [Library Item Expanded](#library-item-expanded) Object
-`item_removed` | A library item was deleted. | [Library Item Expanded](#library-item-expanded) Object
-`items_added` | Library items were created. | Array of [Library Item Expanded](#library-item-expanded)
-`items_updated` | Library items were updated. | Array of [Library Item Expanded](#library-item-expanded)
-`batch_quickmatch_complete` | Batch library item quick matching is complete. | [Batch Quick Match Result](#batch-quick-match-result) Object
-
-### Batch Quick Match Result
-
-> Batch Quick Match Result
-
-```json
-{
-  "success": true,
-  "updates": 3,
-  "unmatched": 0
-}
-```
-
-Attribute | Type | Description
---------- | ---- | -----------
-`success` | Boolean | Whether library items were successfully updated.
-`updates` | Integer | The number of library items that were updated.
-`unmatched` | Integer | The number of library items that a match could not be found for.
-
-
-## Author Events
-
-Name | Description | Schema
----- | ----------- | ------
-`author_added` | An author was created. | [Author](#author) Object
-`author_updated` | An author was updated. | [Author Expanded](#author-expanded) Object
-`author_removed` | An author was deleted. | [Author](#author) Object
-`authors_added` | Authors were created. | Array of [Author](#author)
-
-
-## Series Events
-
-Name | Description | Schema
----- | ----------- | ------
-`series_added` | A series was created. | [Series](#series) Object
-`series_updated` | A series was updated. | [Series](#series) Object
-`multiple_series_added` | Multiple series were created. | Array of [Series](#series)
-
-
-## Collection Events
-
-Name | Description | Schema
----- | ----------- | ------
-`collection_added` | A collection was created. | [Collection Expanded](#collection-expanded) Object
-`collection_updated` | A collection was updated. | [Collection Expanded](#collection-expanded) Object
-`collection_removed` | A collection was deleted. | [Collection Expanded](#collection-expanded) Object
-
-
-## Playlist Events
-
-Name | Description | Schema
----- | ----------- | ------
-`playlist_added` | A playlist was created. | [Playlist Expanded](#playlist-expanded) Object
-`playlist_updated` | A playlist was updated. | [Playlist Expanded](#playlist-expanded) Object
-`playlist_removed` | A playlist was deleted. | [Playlist Expanded](#playlist-expanded) Object
-
-
-## RSS Feed Events
-
-Name | Description | Schema
----- | ----------- | ------
-`rss_feed_open` | An RSS feed was opened. | [RSS Feed Minified](#rss-feed-minified) Object
-`rss_feed_closed` | An RSS feed was closed. | [RSS Feed Minified](#rss-feed-minified) Object
-
-
-## Backup Events
-
-Name | Description | Schema
----- | ----------- | ------
-`backup_applied` | A backup was applied to the server. |
-
-
-## Podcast Episode Download Events
-
-Name | Description | Schema
----- | ----------- | ------
-`episode_download_queued` | A podcast episode has been queued for download. | [Podcast Episode Download](#podcast-episode-download) Object
-`episode_download_queue_updated` | The podcast episode download queue has updated. | Same as [Get a Library's Podcast Episode Downloads](#get-a-library-39-s-podcast-episode-downloads) Response
-`episode_download_started` | A podcast episode has started downloading. | [Podcast Episode Download](#podcast-episode-download) Object
-`episode_download_finished` | A podcast episode has finished downloading. | [Podcast Episode Download](#podcast-episode-download) Object
-
-
 ## Audio Metadata Events
 
 Name | Description | Schema
@@ -391,11 +112,160 @@ Attribute | Type | Description
 `success` | Boolean | Whether the audio file's metadata was successfully updated.
 
 
-## Notification Events
+## Author Events
 
 Name | Description | Schema
 ---- | ----------- | ------
-`notifications_updated` | A notification was fired. | [Notification Settings](#notification-settings) Object
+`author_added` | An author was created. | [Author](#author) Object
+`author_updated` | An author was updated. | [Author Expanded](#author-expanded) Object
+`author_removed` | An author was deleted. | [Author](#author) Object
+`authors_added` | Authors were created. | Array of [Author](#author)
+
+
+## Backup Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`backup_applied` | A backup was applied to the server. |
+
+
+## Client Events
+
+> `auth`
+
+```js
+socket.emit('auth', 'exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY')
+```
+
+> `cancel_scan`
+
+```js
+socket.emit('cancel_scan', 'lib_c1u6t4p45c35rf0nzd')
+```
+
+> `set_log_listener`
+
+```js
+socket.emit('set_log_listener', 2)
+```
+
+> `message_all_users`
+
+```js
+socket.emit('message_all_users', { message: 'Message from admin' })
+```
+
+These are events that clients can emit. See [Miscellaneous Events](#miscellaneous-events) for events that the server responds to these events with.
+
+Name | Description | Schema
+---- | ----------- | ------
+`auth` | Authenticates the socket connection. Causes the server to emit the `init` or `invalid_token` event. | API Token String
+`cancel_scan` | Cancels an in progress library scan. | Library ID String
+`set_log_listener` | Makes the server emit `log` events of the given level or below to the client. | Log Level Integer: `1` for debug, `2` for info, or `3` for warnings, `4` for errors.
+`remove_log_listener` | Removes the client as a log listener. |
+`fetch_daily_logs` | Causes the server to emit the `daily_logs` event. |
+`message_all_users` | **Admin Users Only** Send a message to all users using the `admin_message` server event. | [Message All Users](#message-all-users) Object
+`ping` | Causes the server to emit the `pong` event. |
+
+### Message All Users
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`message` | String | The message to send to all users.
+
+
+## Collection Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`collection_added` | A collection was created. | [Collection Expanded](#collection-expanded) Object
+`collection_updated` | A collection was updated. | [Collection Expanded](#collection-expanded) Object
+`collection_removed` | A collection was deleted. | [Collection Expanded](#collection-expanded) Object
+
+
+## Library Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`library_added` | A library was created. | [Library](#library) Object
+`library_updated` | A library was updated. | [Library](#library) Object
+`library_removed` | A library was deleted. | [Library](#library) Object
+
+
+## Library Item Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`item_added` | A library item was created. | [Library Item Expanded](#library-item-expanded) Object
+`item_updated` | A library item was updated. | [Library Item Expanded](#library-item-expanded) Object
+`item_removed` | A library item was deleted. | [Library Item Expanded](#library-item-expanded) Object
+`items_added` | Library items were created. | Array of [Library Item Expanded](#library-item-expanded)
+`items_updated` | Library items were updated. | Array of [Library Item Expanded](#library-item-expanded)
+`batch_quickmatch_complete` | Batch library item quick matching is complete. | [Batch Quick Match Result](#batch-quick-match-result) Object
+
+### Batch Quick Match Result
+
+> Batch Quick Match Result
+
+```json
+{
+  "success": true,
+  "updates": 3,
+  "unmatched": 0
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`success` | Boolean | Whether library items were successfully updated.
+`updates` | Integer | The number of library items that were updated.
+`unmatched` | Integer | The number of library items that a match could not be found for.
+
+
+## Library Scan Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`scan_start` | A library scan was started. | [Library Scan](#library-scan) Object
+`scan_complete` | A library scan was completed. | [Library Scan](#library-scan) Object
+
+### Library Scan
+
+> Library Scan
+
+```json
+{
+  "id": "lib_yq748byukae93rulli",
+  "type": "scan",
+  "name": "Audiobooks",
+  "results": {...}
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the scanned library.
+`type` | String | The type of the library scan. Will be `scan` or `match`.
+`name` | String | The name of the scanned library.
+`results` | [Library Scan Results](#library-scan-results) Object or null | The results of the library scan. Will be `null` if the scan was canceled.
+
+### Library Scan Results
+
+> Library Scan Results
+
+```json
+{
+  "added": 0,
+  "updated": 0,
+  "missing": 0
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`added` | Integer | The number of library items added during the scan.
+`updated` | Integer | The number of library items updated during the scan.
+`missing` | Integer | The number of library items discovered to be missing during the scan.
 
 
 ## Miscellaneous Events
@@ -450,3 +320,124 @@ Attribute | Type | Description
 `message` | String | The log event's message.
 `levelName` | String | The name of the log level. Can be `DEBUG`, `INFO`, `WARN`, or `ERROR`.
 `level` | Integer | The log event's log level. Can be `1` (debug), `2` (info), `3` (warning), or `4` (error).
+
+## Notification Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`notifications_updated` | A notification was fired. | [Notification Settings](#notification-settings) Object
+
+
+## Playlist Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`playlist_added` | A playlist was created. | [Playlist Expanded](#playlist-expanded) Object
+`playlist_updated` | A playlist was updated. | [Playlist Expanded](#playlist-expanded) Object
+`playlist_removed` | A playlist was deleted. | [Playlist Expanded](#playlist-expanded) Object
+
+
+## Podcast Episode Download Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`episode_download_queued` | A podcast episode has been queued for download. | [Podcast Episode Download](#podcast-episode-download) Object
+`episode_download_queue_updated` | The podcast episode download queue has updated. | Same as [Get a Library's Podcast Episode Downloads](#get-a-library-39-s-podcast-episode-downloads) Response
+`episode_download_started` | A podcast episode has started downloading. | [Podcast Episode Download](#podcast-episode-download) Object
+`episode_download_finished` | A podcast episode has finished downloading. | [Podcast Episode Download](#podcast-episode-download) Object
+
+
+## RSS Feed Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`rss_feed_open` | An RSS feed was opened. | [RSS Feed Minified](#rss-feed-minified) Object
+`rss_feed_closed` | An RSS feed was closed. | [RSS Feed Minified](#rss-feed-minified) Object
+
+
+## Series Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`series_added` | A series was created. | [Series](#series) Object
+`series_updated` | A series was updated. | [Series](#series) Object
+`multiple_series_added` | Multiple series were created. | Array of [Series](#series)
+
+
+## Server Events
+
+The events that the server can emit are in the sections below.
+Events marked with "**Admin Only**" are only sent to sockets with an authenticated admin user.
+
+
+## Stream Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`stream_open` | A stream has opened. | [Stream](#stream) Object
+`stream_closed` | A stream has closed. | Stream ID String
+`stream_progress` | A stream transcode progress update. | [Stream Progress](#stream-progress) Object
+`stream_ready` | A stream is ready, transcoding has already been completed on the requested stream. |
+`stream_reset` | A stream was reset. | [Stream Reset Event](#stream-reset-event) Object
+`stream_error` | A stream error occurred. Emitted when ffmpeg has an error while transcoding. | [Stream Error Event](#stream-error-event) Object
+
+### Stream Reset Event
+
+> Stream Reset Event
+
+```json
+{
+  "startTime": 0,
+  "streamId": "play_c786zm3qtjz6bd5q3n"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`startTime` | Float | The new start time (in seconds) of the stream.
+`streamId` | String | The ID of the stream being reset.
+
+### Stream Error Event
+
+> Stream Error Event
+
+```json
+{
+  "id": "play_c786zm3qtjz6bd5q3n",
+  "error": "ffmpeg exited with code 1"
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the stream where the error occurred.
+`error` | String | The error's message.
+
+
+## User Events
+
+Name | Description | Schema
+---- | ----------- | ------
+`user_online` | **Admin Only** A user is online. | [User with Session and Most Recent Progress](#user-with-session-and-most-recent-progress) Object
+`user_offline` | **Admin Only** A user is offline. | [User with Session and Most Recent Progress](#user-with-session-and-most-recent-progress) Object
+`user_added` | **Admin Only** A user was created. | [User](#user) Object
+`user_updated` | The authenticated user has been updated. | [User](#user) Object
+`user_removed` | **Admin Only** A user was deleted. | [User](#user) Object
+`user_item_progress_updated` | One of the authenticated user's media progress was created/updated. | [User Item Progress Updated Event](#user-item-progress-updated-event)
+`user_stream_update` | **Admin Only** A user started or stopped a playback session. | [User with Session and Most Recent Progress](#user-with-session-and-most-recent-progress) Object
+
+### User Item Progress Updated Event
+
+> User Item Progress Updated Event
+
+```json
+{
+  "id": "li_bufnnmp4y5o2gbbxfm-ep_lh6ko39pumnrma3dhv",
+  "data": {...}
+}
+```
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`id` | String | The ID of the updated media progress.
+`data` | [Media Progress](#media-progress) Object | The updated media progress.

--- a/source/includes/_tools.md
+++ b/source/includes/_tools.md
@@ -1,5 +1,33 @@
 # Tools
 
+## Cancel an M4B Encode Task
+
+```shell
+curl -X DELETE "https://abs.example.com/api/tools/item/li_8gch9ve09orgn4fdz8/encode-m4b" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+This endpoint cancels an in-progress M4B encode task on the server.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/tools/item/<ID>/encode-m4b`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the book library item.
+
+### Response
+
+Status | Meaning | Description
+------ | ------- | -----------
+200 | OK | Success
+403 | Forbidden | The user is not allowed to access the library item, or an admin user is required to cancel an M4B encode task.
+404 | Not Found | No library item with the given ID exists, or no M4B encode task is in-progress for the library item.
+
+
 ## Encode a Book as M4B
 
 ```shell
@@ -35,34 +63,6 @@ Status | Meaning | Description
 403 | Forbidden | The user is not allowed to access the library item, or an admin user is required to make an `.m4b` file.
 404 | Not Found | No library item with the given ID exists, or the library item has missing or invalid files.
 500 | Internal Server Error | The library item is not a book, or does not have audio tracks.
-
-
-## Cancel an M4B Encode Task
-
-```shell
-curl -X DELETE "https://abs.example.com/api/tools/item/li_8gch9ve09orgn4fdz8/encode-m4b" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-This endpoint cancels an in-progress M4B encode task on the server.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/tools/item/<ID>/encode-m4b`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the book library item.
-
-### Response
-
-Status | Meaning | Description
------- | ------- | -----------
-200 | OK | Success
-403 | Forbidden | The user is not allowed to access the library item, or an admin user is required to cancel an M4B encode task.
-404 | Not Found | No library item with the given ID exists, or no M4B encode task is in-progress for the library item.
 
 
 ## Update a Library Item's Audio Files' Embedded Metadata

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -87,6 +87,48 @@ Status | Meaning | Description | Schema
 500 | Internal Server Error | Either the username provided is already taken, or the server failed to save the new user. |
 
 
+## Delete a User
+
+```shell
+curl -X DELETE "https://abs.example.com/api/users/usr_rfk7dgyjp8kg4waewi" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "success": true
+}
+```
+
+This endpoint deletes a user.
+
+### HTTP Request
+
+`DELETE http://abs.example.com/api/users/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the user.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+404 | Not Found | No user with the provided ID exists. |
+500 | Internal Server Error | The root user cannot be deleted and users cannot delete themselves. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`success` | Boolean | Whether the user was successfully deleted.
+
+
 ## Get All Users
 
 ```shell
@@ -490,146 +532,6 @@ Status | Meaning | Description | Schema
 404 | Not Found | No user with the provided ID exists. |
 
 
-## Update a User
-
-```shell
-curl -X PATCH "https://abs.example.com/api/users/root" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
-  -H "Content-Type: application/json" \
-  -d '{"username": "bob", "password": "12345"}'
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": "root",
-  "username": "bob",
-  "type": "root",
-  "token": "exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY",
-  "mediaProgress": [],
-  "seriesHideFromContinueListening": [],
-  "bookmarks": [],
-  "isActive": true,
-  "isLocked": false,
-  "lastSeen": 1667687240810,
-  "createdAt": 1666569607117,
-  "permissions": {
-    "download": true,
-    "update": true,
-    "delete": true,
-    "upload": true,
-    "accessAllLibraries": true,
-    "accessAllTags": true,
-    "accessExplicitContent": true
-  },
-  "librariesAccessible": [],
-  "itemTagsAccessible": []
-}
-```
-
-This endpoint updates a user.
-
-### HTTP Request
-
-`PATCH http://abs.example.com/api/users/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the user.
-
-### Parameters
-
-For the root user, only `username` and `password` are changeable.
-
-Parameter | Type | Description
---------- | ---- | -----------
-`username` | String | The user's username.
-`password` | String | The user's password.
-`type` | String | The user's type. May be `guest`, `user`, or `admin`.
-`seriesHideFromContinueListening` | Array of String | The IDs of series to hide from the user's "Continue Series" shelf.
-`isActive` | Boolean | Whether the user's account is active.
-`permissions` | [User Permissions Parameters](#user-permissions-parameters-2) Object (See Below) | The user's permissions.
-`librariesAccessible` | Array of String | The IDs of libraries that are accessible to the user. An empty array means all libraries are accessible.
-`itemTagsAccessible` | Array of String | The tags that are accessible to the user. An empty array means all tags are accessible.
-
-<aside class="notice">
-When changing a user's username, their token will be regenerated.
-</aside>
-
-#### User Permissions Parameters
-
-Parameter | Type | Description
---------- | ---- | -----------
-`download` | Boolean | Whether the user can download items from the server.
-`update` | Boolean | Whether the user can update library items.
-`delete` | Boolean | Whether the user can delete library items.
-`upload` | Boolean | Whether the user can upload items to the server.
-`accessAllLibraries` | Boolean | Whether the user can access all libraries.
-`accessAllTags` | Boolean | Whether the user can access all tags.
-`accessExplicitContent` | Boolean | Whether the user can access explicit content.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-403 | Forbidden | An admin user is required to edit users and the root user is required to edit the root user. |
-404 | Not Found | No user with the provided ID exists. |
-500 | Internal Server Error | The provided username is already taken. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`success` | Boolean | Whether the user was updated successfully.
-`user` | [User](#user) Object | The updated user.
-
-
-## Delete a User
-
-```shell
-curl -X DELETE "https://abs.example.com/api/users/usr_rfk7dgyjp8kg4waewi" \
-  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY"
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "success": true
-}
-```
-
-This endpoint deletes a user.
-
-### HTTP Request
-
-`DELETE http://abs.example.com/api/users/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the user.
-
-### Response
-
-Status | Meaning | Description | Schema
------- | ------- | ----------- | ------
-200 | OK | Success | See below.
-404 | Not Found | No user with the provided ID exists. |
-500 | Internal Server Error | The root user cannot be deleted and users cannot delete themselves. |
-
-#### Response Schema
-
-Attribute | Type | Description
---------- | ---- | -----------
-`success` | Boolean | Whether the user was successfully deleted.
-
-
 ## Get a User's Listening Sessions
 
 ```shell
@@ -954,3 +856,100 @@ Status | Meaning | Description | Schema
 200 | OK | Success | [User with Progress Details](#user-with-progress-details)
 403 | Forbidden | Only the root user can purge the root user's media progress. |
 404 | Not Found | No user with the provided ID exists. |
+
+## Update a User
+
+```shell
+curl -X PATCH "https://abs.example.com/api/users/root" \
+  -H "Authorization: Bearer exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY" \
+  -H "Content-Type: application/json" \
+  -d '{"username": "bob", "password": "12345"}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "root",
+  "username": "bob",
+  "type": "root",
+  "token": "exJhbGciOiJI6IkpXVCJ9.eyJ1c2Vyi5NDEyODc4fQ.ZraBFohS4Tg39NszY",
+  "mediaProgress": [],
+  "seriesHideFromContinueListening": [],
+  "bookmarks": [],
+  "isActive": true,
+  "isLocked": false,
+  "lastSeen": 1667687240810,
+  "createdAt": 1666569607117,
+  "permissions": {
+    "download": true,
+    "update": true,
+    "delete": true,
+    "upload": true,
+    "accessAllLibraries": true,
+    "accessAllTags": true,
+    "accessExplicitContent": true
+  },
+  "librariesAccessible": [],
+  "itemTagsAccessible": []
+}
+```
+
+This endpoint updates a user.
+
+### HTTP Request
+
+`PATCH http://abs.example.com/api/users/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the user.
+
+### Parameters
+
+For the root user, only `username` and `password` are changeable.
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`username` | String | The user's username.
+`password` | String | The user's password.
+`type` | String | The user's type. May be `guest`, `user`, or `admin`.
+`seriesHideFromContinueListening` | Array of String | The IDs of series to hide from the user's "Continue Series" shelf.
+`isActive` | Boolean | Whether the user's account is active.
+`permissions` | [User Permissions Parameters](#user-permissions-parameters-2) Object (See Below) | The user's permissions.
+`librariesAccessible` | Array of String | The IDs of libraries that are accessible to the user. An empty array means all libraries are accessible.
+`itemTagsAccessible` | Array of String | The tags that are accessible to the user. An empty array means all tags are accessible.
+
+<aside class="notice">
+When changing a user's username, their token will be regenerated.
+</aside>
+
+#### User Permissions Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+`download` | Boolean | Whether the user can download items from the server.
+`update` | Boolean | Whether the user can update library items.
+`delete` | Boolean | Whether the user can delete library items.
+`upload` | Boolean | Whether the user can upload items to the server.
+`accessAllLibraries` | Boolean | Whether the user can access all libraries.
+`accessAllTags` | Boolean | Whether the user can access all tags.
+`accessExplicitContent` | Boolean | Whether the user can access explicit content.
+
+### Response
+
+Status | Meaning | Description | Schema
+------ | ------- | ----------- | ------
+200 | OK | Success | See below.
+403 | Forbidden | An admin user is required to edit users and the root user is required to edit the root user. |
+404 | Not Found | No user with the provided ID exists. |
+500 | Internal Server Error | The provided username is already taken. |
+
+#### Response Schema
+
+Attribute | Type | Description
+--------- | ---- | -----------
+`success` | Boolean | Whether the user was updated successfully.
+`user` | [User](#user) Object | The updated user.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -9,29 +9,29 @@ toc_footers:
   - <a href='https://github.com/slatedocs/slate'>Documentation Powered by Slate</a>
 
 includes:
-  - server
-  - libraries
-  - items
-  - users
-  - collections
-  - playlists
-  - me
-  - backups
-  - filesystem
   - authors
-  - series
-  - sessions
-  - podcasts
-  - notifications
-  - search
+  - backups
   - cache
-  - tools
-  - rss_feeds
-  - misc
-  - socket
-  - metadata_providers
+  - collections
+  - filesystem
   - filtering
+  - items
+  - libraries
+  - me
+  - metadata_providers
+  - misc
+  - notifications
+  - playlists
+  - podcasts
+  - rss_feeds
   - schemas
+  - search
+  - series
+  - server
+  - sessions
+  - socket
+  - tools
+  - users
 
 search: true
 


### PR DESCRIPTION
There may be an issue here or there, so it could use some additional review pre-merge. It was a lot to sort, so it's a lot to verify..

I used a markdown sort script I found on github[1], modified for the format specific to these include pages. Unfortunately, that repo is not licensed so the sort script isn't included here. I will stick it on a gist[2] though for future reference. I generated a static site for preview here: https://itzexor.github.io

1: https://github.com/Logan-Lin/SortMarkdown
2: https://gist.github.com/itzexor/5ce0a1d2d5823ca3b68172d9a8a0e3af